### PR TITLE
PSEC-1873: Bitwarden Vault Exports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,19 @@ ARG PYTHON_VERSION
 
 FROM python:${PYTHON_VERSION}-slim AS base
 
+WORKDIR /build
+
+RUN sed -i 's/http:/https:/g' /etc/apt/sources.list
+RUN apt update && apt -y install curl unzip
+RUN curl -LO "https://github.com/bitwarden/clients/releases/download/cli-v2023.3.0/bw-linux-2023.3.0.zip" && unzip *.zip && rm bw-linux-2023.3.0.zip
+RUN chmod +x bw
+RUN PATH=$PWD:$PATH
+
 RUN pip install \
     --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple \
     --no-cache-dir \
     poetry
 
-WORKDIR /build
 COPY pyproject.toml poetry.lock ./
 
 
@@ -22,7 +29,6 @@ COPY . .
 
 #---- lambda ----
 FROM base AS lambda
-
 
 COPY app.py .
 COPY bitwarden_manager/ bitwarden_manager/

--- a/bitwarden_manager/clients/bitwarden_vault_client.py
+++ b/bitwarden_manager/clients/bitwarden_vault_client.py
@@ -37,5 +37,14 @@ class BitwardenVaultClient:
         else:
             raise Exception("Failed to logout")
 
-    def export_vault(self) -> str:
+    def export_vault(self, password: str) -> str:
+        if not self.__session_token:
+            return "Must unlock vault first"
+        proc = subprocess.Popen([
+            "./bw", "export",
+            "--session", self.__session_token,
+            "--format", "encrypted_json",
+            "--password", password
+        ], stdout=subprocess.PIPE, shell=False)
+        (out, _err) = proc.communicate()
         return "Placeholder"

--- a/bitwarden_manager/clients/bitwarden_vault_client.py
+++ b/bitwarden_manager/clients/bitwarden_vault_client.py
@@ -1,0 +1,41 @@
+import subprocess, os
+from logging import Logger
+
+class BitwardenVaultClient:
+    def __init__(self, logger: Logger, client_id: str, client_secret: str) -> None:
+        self.__logger = logger
+        self.__client_secret = client_secret
+        self.__client_id = client_id
+        self.__session_token = ""
+
+    def login(self) -> str:
+        tmp_env = os.environ.copy()
+        tmp_env["BW_CLIENTID"] = self.__client_id
+        tmp_env["BW_CLIENTSECRET"] = self.__client_secret
+        proc = subprocess.Popen(["./bw", "login", "--apikey"], stdout=subprocess.PIPE, env=tmp_env, shell=False)
+        (out, _err) = proc.communicate()
+        if out:
+            return out.decode("utf-8")
+        else:
+            raise Exception("Failed to login")
+
+    def unlock(self, password: str) -> str:
+        proc = subprocess.Popen(["./bw", "unlock", password], stdout=subprocess.PIPE, shell=False)
+        (out, _err) = proc.communicate()
+        if out:
+            string = out.decode("utf-8")
+            self.__session_token = string.split()[-1]
+            return string
+        else:
+            raise Exception("Failed to unlock")
+
+    def logout(self) -> str:
+        proc = subprocess.Popen(["./bw", "logout"], stdout=subprocess.PIPE, shell=False)
+        (out, _err) = proc.communicate()
+        if out:
+            return out.decode("utf-8")
+        else:
+            raise Exception("Failed to logout")
+
+    def export_vault(self) -> str:
+        return "Placeholder"

--- a/bitwarden_manager/clients/bitwarden_vault_client.py
+++ b/bitwarden_manager/clients/bitwarden_vault_client.py
@@ -1,6 +1,7 @@
-import subprocess
+import subprocess  # nosec B404
 import os
 from logging import Logger
+from typing import Optional
 
 
 class BitwardenVaultClient:
@@ -9,13 +10,15 @@ class BitwardenVaultClient:
         self.__client_secret = client_secret
         self.__client_id = client_id
         self.__password = password
-        self.__session_token = ""
+        self.__session_token: Optional[str] = None
 
     def login(self) -> str:
         tmp_env = os.environ.copy()
         tmp_env["BW_CLIENTID"] = self.__client_id
         tmp_env["BW_CLIENTSECRET"] = self.__client_secret
-        proc = subprocess.Popen(["./bw", "login", "--apikey"], stdout=subprocess.PIPE, env=tmp_env, shell=False)
+        proc = subprocess.Popen(
+            ["./bw", "login", "--apikey"], stdout=subprocess.PIPE, env=tmp_env, shell=False
+        )  # nosec B603
         (out, _err) = proc.communicate()
         if out:
             return out.decode("utf-8")
@@ -23,7 +26,7 @@ class BitwardenVaultClient:
             raise Exception("Failed to login")
 
     def unlock(self) -> str:
-        proc = subprocess.Popen(["./bw", "unlock", self.__password], stdout=subprocess.PIPE, shell=False)
+        proc = subprocess.Popen(["./bw", "unlock", self.__password], stdout=subprocess.PIPE, shell=False)  # nosec B603
         (out, _err) = proc.communicate()
         if out:
             string = out.decode("utf-8")
@@ -33,7 +36,7 @@ class BitwardenVaultClient:
             raise Exception("Failed to unlock")
 
     def logout(self) -> str:
-        proc = subprocess.Popen(["./bw", "logout"], stdout=subprocess.PIPE, shell=False)
+        proc = subprocess.Popen(["./bw", "logout"], stdout=subprocess.PIPE, shell=False)  # nosec B603
         (out, _err) = proc.communicate()
         if out:
             return out.decode("utf-8")
@@ -47,6 +50,6 @@ class BitwardenVaultClient:
             ["./bw", "export", "--session", self.__session_token, "--format", "encrypted_json", "--password", password],
             stdout=subprocess.PIPE,
             shell=False,
-        )
+        )  # nosec B603
         (out, _err) = proc.communicate()
         return "Placeholder"

--- a/bitwarden_manager/clients/bitwarden_vault_client.py
+++ b/bitwarden_manager/clients/bitwarden_vault_client.py
@@ -1,5 +1,7 @@
-import subprocess, os
+import subprocess
+import os
 from logging import Logger
+
 
 class BitwardenVaultClient:
     def __init__(self, logger: Logger, client_id: str, client_secret: str, password: str) -> None:
@@ -41,11 +43,10 @@ class BitwardenVaultClient:
     def export_vault(self, password: str) -> str:
         if not self.__session_token:
             return "Must unlock vault first"
-        proc = subprocess.Popen([
-            "./bw", "export",
-            "--session", self.__session_token,
-            "--format", "encrypted_json",
-            "--password", password
-        ], stdout=subprocess.PIPE, shell=False)
+        proc = subprocess.Popen(
+            ["./bw", "export", "--session", self.__session_token, "--format", "encrypted_json", "--password", password],
+            stdout=subprocess.PIPE,
+            shell=False,
+        )
         (out, _err) = proc.communicate()
         return "Placeholder"

--- a/bitwarden_manager/clients/bitwarden_vault_client.py
+++ b/bitwarden_manager/clients/bitwarden_vault_client.py
@@ -2,10 +2,11 @@ import subprocess, os
 from logging import Logger
 
 class BitwardenVaultClient:
-    def __init__(self, logger: Logger, client_id: str, client_secret: str) -> None:
+    def __init__(self, logger: Logger, client_id: str, client_secret: str, password: str) -> None:
         self.__logger = logger
         self.__client_secret = client_secret
         self.__client_id = client_id
+        self.__password = password
         self.__session_token = ""
 
     def login(self) -> str:
@@ -19,8 +20,8 @@ class BitwardenVaultClient:
         else:
             raise Exception("Failed to login")
 
-    def unlock(self, password: str) -> str:
-        proc = subprocess.Popen(["./bw", "unlock", password], stdout=subprocess.PIPE, shell=False)
+    def unlock(self) -> str:
+        proc = subprocess.Popen(["./bw", "unlock", self.__password], stdout=subprocess.PIPE, shell=False)
         (out, _err) = proc.communicate()
         if out:
             string = out.decode("utf-8")

--- a/bitwarden_manager/export_vault.py
+++ b/bitwarden_manager/export_vault.py
@@ -1,0 +1,25 @@
+from typing import Dict, Any
+
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+
+from jsonschema import validate
+
+export_vault_event_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "password": {"type": "string", "description": "password to encrypt the export with"},
+    },
+    "required": ["password"],
+}
+
+
+class ExportVault:
+    def __init__(self, bitwarden_vault_client: BitwardenVaultClient):
+        self.bitwarden_vault_client = bitwarden_vault_client
+
+    def run(self, event: Dict[str, Any]) -> None:
+        validate(instance=event, schema=export_vault_event_schema)
+        self.bitwarden_vault_client.export_vault(
+            password=event["password"],
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1830,6 +1830,23 @@ url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
 reference = "artifactory"
 
 [[package]]
+name = "types-mock"
+version = "5.0.0.6"
+description = "Typing stubs for mock"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-mock-5.0.0.6.tar.gz", hash = "sha256:3abdee238948c6678ef5b4fd740bd41d30289a2fe4d91aac4ae9f6869e6c9333"},
+    {file = "types_mock-5.0.0.6-py3-none-any.whl", hash = "sha256:6946f4b2240160a1740db7d6c8e8736705acd133afd98555897db0116d41a6fc"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
+reference = "artifactory"
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.9"
 description = "Typing stubs for PyYAML"
@@ -1971,4 +1988,4 @@ reference = "artifactory"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "11738ab860039fa1c488a0745a8ce2d52a1bd795e512c326dcd7841a6ce209c4"
+content-hash = "b54187262ce7a9229a5a29f3076a6f29e705d11e82418a01afca12f68da69719"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1112,6 +1112,28 @@ url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
 reference = "artifactory"
 
 [[package]]
+name = "mock"
+version = "5.0.2"
+description = "Rolling backport of unittest.mock for all Pythons"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mock-5.0.2-py3-none-any.whl", hash = "sha256:0e0bc5ba78b8db3667ad636d964eb963dc97a59f04c6f6214c5f0e4a8f726c56"},
+    {file = "mock-5.0.2.tar.gz", hash = "sha256:06f18d7d65b44428202b145a9a36e99c2ee00d1eb992df0caf881d4664377891"},
+]
+
+[package.extras]
+build = ["blurb", "twine", "wheel"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
+
+[package.source]
+type = "legacy"
+url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
+reference = "artifactory"
+
+[[package]]
 name = "mypy"
 version = "1.2.0"
 description = "Optional static typing for Python"
@@ -1949,4 +1971,4 @@ reference = "artifactory"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "bade24561d82f1c666f0531ca223e1029aebc4334963d1c607b5cc44335bdb5b"
+content-hash = "11738ab860039fa1c488a0745a8ce2d52a1bd795e512c326dcd7841a6ce209c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-cov = "^4.0.0"
 responses = "^0.23.1"
 bandit = "^1.7.5"
 pre-commit = "^3.3.1"
+mock = "^5.0.2"
 
 
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ responses = "^0.23.1"
 bandit = "^1.7.5"
 pre-commit = "^3.3.1"
 mock = "^5.0.2"
+types-mock = "^5.0.0.6"
 
 
 [tool.flake8]

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -1,60 +1,108 @@
 import logging
 import pytest
+import mock
 
 from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+
+
+class MockedPopen:
+    def __init__(self, args, **kwargs):
+        self.args = args
+        self.returncode = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, value, traceback):
+        pass
+
+    def communicate(self, input=None, timeout=None):
+        if self.args[0] == "./bw" and self.args[1] == "login":
+            stdout = b"You are logged in!\n\nTo unlock your vault, use the `unlock` command. ex:\n$ bw unlock"
+            stderr = ""
+            self.returncode = 0
+        elif self.args[0] == "./bw" and self.args[1] == "logout":
+            stdout = b"You have logged out."
+            stderr = ""
+            self.returncode = 0
+        elif self.args[0] == "./bw" and self.args[1] == "unlock":
+            stdout = b"Unlocked"
+            stderr = ""
+            self.returncode = 0
+        elif self.args[0] == "./bw" and self.args[1] == "export":
+            stdout = b"Placeholder"
+            stderr = ""
+            self.returncode = 0
+        else:
+            stdout = ""
+            stderr = b"unknown command"
+            self.returncode = 1
+        return stdout, stderr
+
+
+class FailedMockedPopen:
+    def __init__(self, args, **kwargs):
+        self.args = args
+        self.returncode = 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, value, traceback):
+        pass
+
+    def communicate(self, input=None, timeout=None):
+        stdout = ""
+        stderr = b"Command failed"
+        self.returncode = 1
+        return stdout, stderr
+
 
 @pytest.fixture
 def client():
     return BitwardenVaultClient(
-        logger=logging.getLogger(),
-        client_id="<Insert valid cred>",
-        client_secret="<Insert valid cred>",
-        password="<Insert valid cred>"
+        logger=logging.getLogger(), client_id="test_id", client_secret="test_secret", password="very secure pa$$w0rd!"
     )
 
-@pytest.fixture
-def client_invalid_password():
-    return BitwardenVaultClient(
-        logger=logging.getLogger(),
-        client_id="<Insert valid cred>",
-        client_secret="<Insert valid cred>",
-        password="baz"
-    )
 
-@pytest.fixture
-def invalid_client():
-    return BitwardenVaultClient(
-        logger=logging.getLogger(),
-        client_id="foo",
-        client_secret="bar",
-        password="baz"
-    )
-
-def test_failed_login(invalid_client) -> None:
-    with pytest.raises(Exception, match="Failed to login"):
-        invalid_client.login()
-
-def test_failed_logout(invalid_client) -> None:
-    with pytest.raises(Exception, match="Failed to logout"):
-        invalid_client.logout()
-
+@mock.patch("subprocess.Popen", MockedPopen)
 def test_login(client) -> None:
     result = client.login()
     assert result == "You are logged in!\n\nTo unlock your vault, use the `unlock` command. ex:\n$ bw unlock"
 
-def test_failed_unlock(client_invalid_password) -> None:
-    with pytest.raises(Exception, match="Failed to unlock"):
-        client_invalid_password.unlock()
 
+@mock.patch("subprocess.Popen", FailedMockedPopen)
+def test_failed_login(client) -> None:
+    with pytest.raises(Exception, match="Failed to login"):
+        client.login()
+
+
+@mock.patch("subprocess.Popen", MockedPopen)
 def test_export_without_unlock(client) -> None:
     result = client.export_vault("Encyption Pa$$w0rd")
     assert result == "Must unlock vault first"
 
+
+@mock.patch("subprocess.Popen", MockedPopen)
 def test_export_vault(client) -> None:
     client.unlock()
     result = client.export_vault("Encyption Pa$$w0rd")
     assert result == "Placeholder"
 
+
+@mock.patch("subprocess.Popen", FailedMockedPopen)
+def test_failed_unlock(client) -> None:
+    with pytest.raises(Exception, match="Failed to unlock"):
+        client.unlock()
+
+
+@mock.patch("subprocess.Popen", MockedPopen)
 def test_logout(client) -> None:
     result = client.logout()
     assert result == "You have logged out."
+
+
+@mock.patch("subprocess.Popen", FailedMockedPopen)
+def test_failed_logout(client) -> None:
+    with pytest.raises(Exception, match="Failed to logout"):
+        client.logout()

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -1,0 +1,48 @@
+import logging
+import pytest
+
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+
+@pytest.fixture
+def client():
+    return BitwardenVaultClient(
+        logger=logging.getLogger(),
+        client_id="<Insert valid cred>",
+        client_secret="<Insert valid cred>",
+    )
+
+@pytest.fixture
+def invalid_client():
+    return BitwardenVaultClient(
+        logger=logging.getLogger(),
+        client_id="foo",
+        client_secret="bar",
+    )
+
+def test_failed_login(invalid_client) -> None:
+    with pytest.raises(Exception, match="Failed to login"):
+        invalid_client.login()
+
+def test_failed_logout(invalid_client) -> None:
+    with pytest.raises(Exception, match="Failed to logout"):
+        invalid_client.logout()
+
+def test_login(client) -> None:
+    result = client.login()
+    assert result == "You are logged in!\n\nTo unlock your vault, use the `unlock` command. ex:\n$ bw unlock"
+
+def test_failed_unlock(client) -> None:
+    with pytest.raises(Exception, match="Failed to unlock"):
+        client.unlock("Incorrect password")
+
+def test_unlock(client) -> None:
+    result = client.unlock("<Insert password>")
+    assert "Your vault is now unlocked!" in result
+
+def test_logout(client) -> None:
+    result = client.logout()
+    assert result == "You have logged out."
+
+def test_export_vault(client) -> None:
+    result = client.export_vault()
+    assert result == "Placeholder"

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -2,107 +2,109 @@ import logging
 import pytest
 import mock
 
+from typing import Optional
+from typing import Self
 from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
 
 
 class MockedPopen:
-    def __init__(self, args, **kwargs):
+    def __init__(self, args: str, **kwargs: str) -> None:
         self.args = args
         self.returncode = 0
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, value, traceback):
+    def __exit__(self, exc_type: str, value: str, traceback: str) -> None:
         pass
 
-    def communicate(self, input=None, timeout=None):
+    def communicate(self, input: Optional[str] = None, timeout: Optional[int] = None) -> tuple[bytes, bytes]:
         if self.args[0] == "./bw" and self.args[1] == "login":
             stdout = b"You are logged in!\n\nTo unlock your vault, use the `unlock` command. ex:\n$ bw unlock"
-            stderr = ""
+            stderr = b""
             self.returncode = 0
         elif self.args[0] == "./bw" and self.args[1] == "logout":
             stdout = b"You have logged out."
-            stderr = ""
+            stderr = b""
             self.returncode = 0
         elif self.args[0] == "./bw" and self.args[1] == "unlock":
             stdout = b"Unlocked"
-            stderr = ""
+            stderr = b""
             self.returncode = 0
         elif self.args[0] == "./bw" and self.args[1] == "export":
             stdout = b"Placeholder"
-            stderr = ""
+            stderr = b""
             self.returncode = 0
         else:
-            stdout = ""
+            stdout = b""
             stderr = b"unknown command"
             self.returncode = 1
         return stdout, stderr
 
 
 class FailedMockedPopen:
-    def __init__(self, args, **kwargs):
+    def __init__(self, args: str, **kwargs: str) -> None:
         self.args = args
         self.returncode = 1
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, value, traceback):
+    def __exit__(self, exc_type: str, value: str, traceback: str) -> None:
         pass
 
-    def communicate(self, input=None, timeout=None):
-        stdout = ""
+    def communicate(self, input: Optional[str] = None, timeout: Optional[int] = None) -> tuple[bytes, bytes]:
+        stdout = b""
         stderr = b"Command failed"
         self.returncode = 1
         return stdout, stderr
 
 
 @pytest.fixture
-def client():
+def client() -> BitwardenVaultClient:
     return BitwardenVaultClient(
         logger=logging.getLogger(), client_id="test_id", client_secret="test_secret", password="very secure pa$$w0rd!"
     )
 
 
 @mock.patch("subprocess.Popen", MockedPopen)
-def test_login(client) -> None:
+def test_login(client: BitwardenVaultClient) -> None:
     result = client.login()
     assert result == "You are logged in!\n\nTo unlock your vault, use the `unlock` command. ex:\n$ bw unlock"
 
 
 @mock.patch("subprocess.Popen", FailedMockedPopen)
-def test_failed_login(client) -> None:
+def test_failed_login(client: BitwardenVaultClient) -> None:
     with pytest.raises(Exception, match="Failed to login"):
         client.login()
 
 
 @mock.patch("subprocess.Popen", MockedPopen)
-def test_export_without_unlock(client) -> None:
+def test_export_without_unlock(client: BitwardenVaultClient) -> None:
     result = client.export_vault("Encyption Pa$$w0rd")
     assert result == "Must unlock vault first"
 
 
 @mock.patch("subprocess.Popen", MockedPopen)
-def test_export_vault(client) -> None:
+def test_export_vault(client: BitwardenVaultClient) -> None:
     client.unlock()
     result = client.export_vault("Encyption Pa$$w0rd")
     assert result == "Placeholder"
 
 
 @mock.patch("subprocess.Popen", FailedMockedPopen)
-def test_failed_unlock(client) -> None:
+def test_failed_unlock(client: BitwardenVaultClient) -> None:
     with pytest.raises(Exception, match="Failed to unlock"):
         client.unlock()
 
 
 @mock.patch("subprocess.Popen", MockedPopen)
-def test_logout(client) -> None:
+def test_logout(client: BitwardenVaultClient) -> None:
     result = client.logout()
     assert result == "You have logged out."
 
 
 @mock.patch("subprocess.Popen", FailedMockedPopen)
-def test_failed_logout(client) -> None:
+def test_failed_logout(client: BitwardenVaultClient) -> None:
     with pytest.raises(Exception, match="Failed to logout"):
         client.logout()

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -9,6 +9,16 @@ def client():
         logger=logging.getLogger(),
         client_id="<Insert valid cred>",
         client_secret="<Insert valid cred>",
+        password="<Insert valid cred>"
+    )
+
+@pytest.fixture
+def client_invalid_password():
+    return BitwardenVaultClient(
+        logger=logging.getLogger(),
+        client_id="<Insert valid cred>",
+        client_secret="<Insert valid cred>",
+        password="baz"
     )
 
 @pytest.fixture
@@ -17,6 +27,7 @@ def invalid_client():
         logger=logging.getLogger(),
         client_id="foo",
         client_secret="bar",
+        password="baz"
     )
 
 def test_failed_login(invalid_client) -> None:
@@ -31,16 +42,16 @@ def test_login(client) -> None:
     result = client.login()
     assert result == "You are logged in!\n\nTo unlock your vault, use the `unlock` command. ex:\n$ bw unlock"
 
-def test_failed_unlock(client) -> None:
+def test_failed_unlock(client_invalid_password) -> None:
     with pytest.raises(Exception, match="Failed to unlock"):
-        client.unlock("Incorrect password")
+        client_invalid_password.unlock()
 
 def test_export_without_unlock(client) -> None:
     result = client.export_vault("Encyption Pa$$w0rd")
     assert result == "Must unlock vault first"
 
 def test_export_vault(client) -> None:
-    client.unlock("<Insert password>")
+    client.unlock()
     result = client.export_vault("Encyption Pa$$w0rd")
     assert result == "Placeholder"
 

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -35,14 +35,15 @@ def test_failed_unlock(client) -> None:
     with pytest.raises(Exception, match="Failed to unlock"):
         client.unlock("Incorrect password")
 
-def test_unlock(client) -> None:
-    result = client.unlock("<Insert password>")
-    assert "Your vault is now unlocked!" in result
+def test_export_without_unlock(client) -> None:
+    result = client.export_vault("Encyption Pa$$w0rd")
+    assert result == "Must unlock vault first"
+
+def test_export_vault(client) -> None:
+    client.unlock("<Insert password>")
+    result = client.export_vault("Encyption Pa$$w0rd")
+    assert result == "Placeholder"
 
 def test_logout(client) -> None:
     result = client.logout()
     assert result == "You have logged out."
-
-def test_export_vault(client) -> None:
-    result = client.export_vault()
-    assert result == "Placeholder"

--- a/tests/bitwarden_manager/test_bitwarden_manager.py
+++ b/tests/bitwarden_manager/test_bitwarden_manager.py
@@ -38,6 +38,7 @@ def test_get_bitwarden_api_creds(mock_secretsmanager: Mock) -> None:
         ]
     )
 
+
 @mock.patch("boto3.client")
 def test_get_bitwarden_vault_creds(mock_secretsmanager: Mock) -> None:
     get_secret_value = Mock(return_value={"SecretString": "secret"})

--- a/tests/bitwarden_manager/test_bitwarden_manager.py
+++ b/tests/bitwarden_manager/test_bitwarden_manager.py
@@ -20,7 +20,7 @@ def test_get_ldap_credentials(mock_secretsmanager: Mock) -> None:
 
 
 @mock.patch("boto3.client")
-def test_get_bitwarden_creds(mock_secretsmanager: Mock) -> None:
+def test_get_bitwarden_api_creds(mock_secretsmanager: Mock) -> None:
     get_secret_value = Mock(return_value={"SecretString": "secret"})
     mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
     manager = BitwardenManager()
@@ -35,5 +35,28 @@ def test_get_bitwarden_creds(mock_secretsmanager: Mock) -> None:
         [
             call(SecretId="/bitwarden/api-client-id"),
             call(SecretId="/bitwarden/api-client-secret"),
+        ]
+    )
+
+@mock.patch("boto3.client")
+def test_get_bitwarden_vault_creds(mock_secretsmanager: Mock) -> None:
+    get_secret_value = Mock(return_value={"SecretString": "secret"})
+    mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
+    manager = BitwardenManager()
+
+    assert manager._get_bitwarden_vault_client_id() == "secret"
+    assert get_secret_value.call_count == 1
+    get_secret_value.assert_has_calls([call(SecretId="/bitwarden/vault-client-id")])
+
+    assert manager._get_bitwarden_vault_client_secret() == "secret"
+    assert get_secret_value.call_count == 2
+
+    assert manager._get_bitwarden_vault_password() == "secret"
+    assert get_secret_value.call_count == 3
+    get_secret_value.assert_has_calls(
+        [
+            call(SecretId="/bitwarden/vault-client-id"),
+            call(SecretId="/bitwarden/vault-client-secret"),
+            call(SecretId="/bitwarden/vault-password"),
         ]
     )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@ from _pytest.logging import LogCaptureFixture
 from app import handler
 from bitwarden_manager.clients.aws_secretsmanager_client import AwsSecretsManagerClient
 from bitwarden_manager.onboard_user import OnboardUser
+from bitwarden_manager.export_vault import ExportVault
 
 
 @mock.patch("boto3.client")
@@ -40,6 +41,14 @@ def test_handler_ignores_unknown_events(boto_mock: Mock, caplog: LogCaptureFixtu
 def test_handler_routes_new_user_events(boto_mock: Mock) -> None:
     event = dict(event_name="new_user")
     with patch.object(OnboardUser, "run") as mock_method:
+        handler(event=event, context={})
+
+    mock_method.assert_called_once_with(event=event)
+
+@mock.patch("boto3.client")
+def test_handler_routes_export_vault_events(boto_mock: Mock) -> None:
+    event = dict(event_name="export_vault")
+    with patch.object(ExportVault, "run") as mock_method:
         handler(event=event, context={})
 
     mock_method.assert_called_once_with(event=event)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -45,6 +45,7 @@ def test_handler_routes_new_user_events(boto_mock: Mock) -> None:
 
     mock_method.assert_called_once_with(event=event)
 
+
 @mock.patch("boto3.client")
 def test_handler_routes_export_vault_events(boto_mock: Mock) -> None:
     event = dict(event_name="export_vault")

--- a/tests/test_export_vault.py
+++ b/tests/test_export_vault.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+from bitwarden_manager.export_vault import ExportVault
+
+
+def test_export_vault() -> None:
+    event = {"password": "Encryption Pa$$w0rd"}
+    mock_client = Mock(spec=BitwardenVaultClient)
+
+    ExportVault(bitwarden_vault_client=mock_client).run(event)
+
+    mock_client.export_vault.assert_called_with(password="Encryption Pa$$w0rd")
+
+
+def test_export_vault_rejects_bad_events() -> None:
+    event = {"somthing?": 1}
+    mock_client = Mock(spec=BitwardenVaultClient)
+
+    with pytest.raises(ValidationError, match="'password' is a required property"):
+        ExportVault(bitwarden_vault_client=mock_client).run(event)
+
+    assert not mock_client.export_vault.called


### PR DESCRIPTION
The assumptions here:

-  This task will run in the same lambda as onboarding users just with a different event trigger. 
- PlatSec labs account will have Bitwarden test account credentials
- Platsec production will have Bitwarden production account credentials
- We will encrypt exports with our own password rather than with the Bitwarden account encryption key (so that we can recover the file contents in case of Bitwarden themselves having catastrophic downtime). The password is passed into the lambda in the event payload. **We should check that is secure**. It would be trivial to switch to using Bitwarden account encryption key is that's preferred though.




TODO:

Terraform/Bitwarden
- [ ] - [ ] Onboard automation user in Bitwarden test and production account (whose credentials will be used)
- [ ] - [ ] Setup infra on sandbox and prod (vault_client_id, vault_secret, vault_password, S3 bucket)


Python
- [x] Vault login/logout
- [x] Vault unlock
- [x] Capture unlock session token
- [x] Vault export to encrypted JSON
- [ ] Store encrypted JSON in S3 (once buckets have been terraformed)
- [x] Lambda event to trigger this flow
- [x] Mock out subprocess in tests so that we're not making real API calls
- [ ] Store creds in sandbox and production (once secrets have been terraformed)
