### PR TITLE
PSEC-1850 create bitwarden groups/collections automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage.xml
 __pycache__
 .vscode
 .DS_Store
+bw
+docker.tar
+event.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       #     name: Checking local hooks against latest release
       #     verbose: true
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.3.0
+      rev: v4.4.0
       hooks:
           - id: end-of-file-fixer
           - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below are the events that this lambda accepts
 ### New user
 
 Sending this event will invite a new user to the org.
-If the user already exists then the lambda will log this and exit successfully.
+If the user already exists within BitWarden then the lambda will log this.
 
 ```json
 {
@@ -19,6 +19,12 @@ If the user already exists then the lambda will log this and exit successfully.
     "email": "test-email@example.com"
 }
 ```
+
+This passes the `username` to the user-management portal. This retrieves the users assigned teams.
+Subsequently, a group & collection is associated to the new user within BitWarden.
+
+The user is granted `edit` privileges on the group/collection they're assigned to.
+More information regarding access control can be found here [Bitwarden Access Control](https://bitwarden.com/help/user-types-access-control/#permissions)
 
 ### Export Vault
 

--- a/bitwarden_manager/bitwarden_manager.py
+++ b/bitwarden_manager/bitwarden_manager.py
@@ -25,6 +25,7 @@ class BitwardenManager:
                 OnboardUser(
                     bitwarden_api=self._get_bitwarden_public_api(),
                     user_management_api=self._get_user_management_api(),
+                    bitwarden_vault_client=self._get_bitwarden_vault_client(),
                 ).run(event=event)
             case "export_vault":
                 self.__logger.debug("handling event with ExportVault")

--- a/bitwarden_manager/bitwarden_manager.py
+++ b/bitwarden_manager/bitwarden_manager.py
@@ -5,6 +5,7 @@ import boto3
 from bitwarden_manager.clients.aws_secretsmanager_client import AwsSecretsManagerClient
 from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
 from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+from bitwarden_manager.clients.user_management_api import UserManagementApi
 from bitwarden_manager.onboard_user import OnboardUser
 from bitwarden_manager.export_vault import ExportVault
 from bitwarden_manager.redacting_formatter import get_bitwarden_logger
@@ -21,7 +22,10 @@ class BitwardenManager:
             case "new_user":
                 self.__logger.info(f"retrieved ldap creds with username {self._get_ldap_username()}")
                 self.__logger.debug("handling event with OnboardUser")
-                OnboardUser(bitwarden_api=self._get_bitwarden_public_api()).run(event=event)
+                OnboardUser(
+                    bitwarden_api=self._get_bitwarden_public_api(),
+                    user_management_api=self._get_user_management_api(),
+                ).run(event=event)
             case "export_vault":
                 self.__logger.debug("handling event with ExportVault")
                 ExportVault(bitwarden_vault_client=self._get_bitwarden_vault_client()).run(event=event)
@@ -42,6 +46,13 @@ class BitwardenManager:
             client_secret=self._get_bitwarden_vault_client_secret(),
             password=self._get_bitwarden_vault_password(),
             export_enc_password=self._get_bitwarden_export_encryption_password(),
+        )
+
+    def _get_user_management_api(self) -> UserManagementApi:
+        return UserManagementApi(
+            logger=self.__logger,
+            client_id=self._get_ldap_username(),
+            client_secret=self._get_ldap_password(),
         )
 
     def _get_bitwarden_client_id(self) -> str:

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -1,12 +1,15 @@
 from logging import Logger
-from typing import Dict
-from requests import post, HTTPError
+from typing import Dict, List, Any
+
+from requests import HTTPError, Session
 
 REGULAR_USER = 2
 REQUEST_TIMEOUT_SECONDS = 30
 
 LOGIN_URL = "https://identity.bitwarden.com/connect/token"
 API_URL = "https://api.bitwarden.com/public"
+
+session = Session()
 
 
 class BitwardenPublicApi:
@@ -15,34 +18,29 @@ class BitwardenPublicApi:
         self.__client_secret = client_secret
         self.__client_id = client_id
 
-    def invite_user(self, username: str, email: str) -> None:
-        bearer = self.__fetch_token()
-        response = post(
-            f"{API_URL}/members",
-            headers={"Authorization": f"Bearer {bearer}"},
-            json={
-                "type": REGULAR_USER,
-                "accessAll": False,
-                "resetPasswordEnrolled": True,
-                "externalId": username,
-                "email": email,
-                "collections": [],
-            },
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
+    def __get_user_groups(self, user_id: str) -> List[str]:
+        response = session.get(f"{API_URL}/members/{user_id}/group-ids")
         try:
             response.raise_for_status()
-        except HTTPError as e:
-            if (
-                response.status_code == 400
-                and response.json().get("message", None) == "This user has already been invited."
-            ):
-                self.__logger.info("user already invited ignoring error")
-            else:
-                raise Exception("Failed to invite user", response.content, e) from e
+        except HTTPError as error:
+            raise Exception("Failed to get user groups", response.content, error) from error
+        response_list: List[str] = response.json()
+        return response_list
+
+    def __fetch_user_id(self, email: str) -> str:
+        response = session.get(f"{API_URL}/members")
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to retrieve users", response.content, error) from error
+        response_json: Dict[str, Any] = response.json()
+        for user in response_json.get("data", ""):
+            if email == user.get("email", ""):
+                return str(user.get("id", ""))
+        return ""
 
     def __fetch_token(self) -> str:
-        response = post(
+        response = session.post(
             LOGIN_URL,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
@@ -55,8 +53,156 @@ class BitwardenPublicApi:
         )
         try:
             response.raise_for_status()
-        except HTTPError as e:
-            raise Exception(f"Failed to authenticate with {LOGIN_URL}, creds incorrect?", e) from e
-
+        except HTTPError as error:
+            raise Exception(f"Failed to authenticate with {LOGIN_URL}, creds incorrect?", error) from error
         response_json: Dict[str, str] = response.json()
-        return response_json["access_token"]
+        access_token = response_json["access_token"]
+        session.headers.update({"Authorization": f"Bearer {access_token}"})
+        return access_token
+
+    def __get_collection_groups(self, collection_id: str) -> set[str]:
+        response = session.get(f"{API_URL}/collections/{collection_id}")
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to get collections", response.content, error) from error
+        response_json: Dict[str, Any] = response.json()
+        group_ids = {group.get("id", "") for group in response_json.get("groups", "")}
+        return group_ids
+
+    def invite_user(self, username: str, email: str) -> str:
+        self.__fetch_token()
+        response = session.post(
+            f"{API_URL}/members",
+            json={
+                "type": REGULAR_USER,
+                "accessAll": False,
+                "resetPasswordEnrolled": True,
+                "externalId": username,
+                "email": email,
+                "collections": [],
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            if (
+                response.status_code == 400
+                and response.json().get("message", None) == "This user has already been invited."
+            ):
+                self.__logger.info("user already invited ignoring error")
+                return self.__fetch_user_id(email)
+            raise Exception("Failed to invite user", response.content, error) from error
+        response_json: Dict[str, str] = response.json()
+        return response_json.get("id", "")
+
+    def list_existing_groups(self, users_teams: List[str]) -> Dict[str, str]:
+        existing_groups: Dict[str, str] = {}
+        response = session.get(f"{API_URL}/groups")
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to list groups", response.content, error) from error
+        response_json: Dict[str, Any] = response.json()
+        for group in response_json.get("data", {}):
+            if group.get("name", "") in users_teams:
+                if not existing_groups.get(group.get("name")):
+                    existing_groups[group.get("name")] = group.get("id")
+                else:
+                    existing_groups[group.get("name")] = "duplicate"
+        return existing_groups
+
+    def create_group(self, group_name: str, collection_id: str) -> str:
+        if len(group_name) == 0 or len(group_name) > 100:
+            self.__logger.info(f"Group name invalid: {group_name}")
+            return ""
+
+        json_id = []
+        if collection_id:
+            json_id.append({"id": collection_id, "readOnly": False})
+
+        response = session.post(
+            f"{API_URL}/groups",
+            json={
+                "name": group_name,
+                "accessAll": False,
+                "collections": json_id,
+                "externalId": group_name,
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to create group", response.content, error) from error
+        response_json: Dict[str, Any] = response.json()
+        return response_json.get("id", "")
+
+    def associate_user_to_groups(self, user_id: str, group_ids: List[str]) -> None:
+        existing_user_group_ids = self.__get_user_groups(user_id)
+        for existing_group_id in existing_user_group_ids:
+            if existing_group_id not in group_ids:
+                group_ids.append(existing_group_id)
+        response = session.put(
+            f"{API_URL}/members/{user_id}/group-ids",
+            json={"groupIds": group_ids},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to associate user to group-ids", response.content, error) from error
+
+    def update_collection_groups(self, collection_name: str, collection_id: str, group_id: str) -> None:
+        group_ids = self.__get_collection_groups(collection_id)
+        if group_id in group_ids:
+            self.__logger.info("Group already exists in collection")
+            return
+        group_ids.add(group_id)
+        group_json = [{"id": group_id, "readOnly": False} for group_id in group_ids]
+        response = session.put(
+            f"{API_URL}/collections/{collection_id}",
+            json={
+                "externalId": collection_name,
+                "groups": group_json,
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to associate collection to group-ids", response.content, error) from error
+
+    def list_existing_collections(self, teams: List[str]) -> Dict[str, str]:
+        collections: Dict[str, str] = {}
+        response = session.get(f"{API_URL}/collections")
+        try:
+            response.raise_for_status()
+            response_json: Dict[str, Any] = response.json()
+            for collection_object in response_json.get("data", {}):
+                if collection_object.get("externalId", "") in teams:
+                    if not collections.get(collection_object.get("externalId")):
+                        collections[collection_object.get("externalId")] = collection_object.get("id")
+                    else:
+                        collections[collection_object.get("externalId")] = "duplicate"
+            return collections
+        except HTTPError as error:
+            raise Exception("Failed to list collections", response.content, error) from error
+
+    def collate_user_group_ids(
+        self, teams: List[str], groups: Dict[str, str], collections: Dict[str, str]
+    ) -> List[str]:
+        groups_ids = []
+        for team in teams:
+            collection_id = collections.get(team, "")
+            group_id = groups.get(team, "")
+            if "duplicate" not in (group_id, collection_id):
+                if not group_id:
+                    group_id = self.create_group(group_name=team, collection_id=collection_id)
+                if collection_id and group_id:
+                    self.update_collection_groups(team, collection_id, group_id)
+                groups_ids.append(group_id)
+            else:
+                raise Exception(f"There are duplicate groups or collections for {team}")
+        return groups_ids

--- a/bitwarden_manager/clients/user_management_api.py
+++ b/bitwarden_manager/clients/user_management_api.py
@@ -1,0 +1,62 @@
+from logging import Logger
+from typing import Dict, Any
+from requests import get, post, HTTPError
+
+REQUEST_TIMEOUT_SECONDS = 5
+
+API_URL = "https://user-management-backend-production.tools.tax.service.gov.uk/v2"
+AUTH_URL = "https://user-management-auth-production.tools.tax.service.gov.uk/v1/login"
+
+
+class UserManagementApi:
+    def __init__(self, logger: Logger, client_id: str, client_secret: str) -> None:
+        self.__logger = logger
+        self.__client_secret = client_secret
+        self.__client_id = client_id
+
+    def get_user_teams(self, username: str) -> list[str]:
+        user_teams = []
+        bearer = self.__fetch_token()
+        response = get(
+            f"{API_URL}/organisations/users/{username}/teams",
+            headers={
+                "Token": bearer,
+                "requester": self.__client_id,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            if response.status_code == 404 and response.json().get("reason", None) == "Not Found":
+                self.__logger.info("User Not Found")
+            elif response.status_code == 422 and response.json().get("reason", None) == "Invalid uid":
+                self.__logger.info("Invalid User")
+            else:
+                raise Exception("Failed to get teams for user", response.content, e) from e
+        response_json: Dict[str, Any] = response.json()
+        if response_json.get("teams"):
+            for team in response_json.get("teams", {}):
+                user_teams.append(team.get("team", ""))
+        self.__logger.info(f"ump_teams: {user_teams}")
+        return user_teams
+
+    def __fetch_token(self) -> str:
+        response = post(
+            AUTH_URL,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            json={
+                "username": self.__client_id,
+                "password": self.__client_secret,
+            },
+            timeout=15,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            raise Exception(f"Failed to authenticate with {AUTH_URL}, creds incorrect?", e) from e
+
+        response_json: Dict[str, str] = response.json()
+        return response_json.get("Token", "")

--- a/bitwarden_manager/export_vault.py
+++ b/bitwarden_manager/export_vault.py
@@ -9,8 +9,7 @@ class ExportVault:
         self.bitwarden_vault_client = bitwarden_vault_client
 
     def run(self, event: Dict[str, Any]) -> None:
-        org_id = os.environ["ORGANISATION_ID"]
         bucket_name = os.environ["BITWARDEN_BACKUP_BUCKET"]
-        filepath = self.bitwarden_vault_client.export_vault(org_id=org_id)
+        filepath = self.bitwarden_vault_client.export_vault()
         self.bitwarden_vault_client.write_file_to_s3(bucket_name, filepath)
         self.bitwarden_vault_client.logout()

--- a/bitwarden_manager/onboard_user.py
+++ b/bitwarden_manager/onboard_user.py
@@ -18,13 +18,29 @@ onboard_user_event_schema = {
 
 
 class OnboardUser:
-    def __init__(self, bitwarden_api: BitwardenPublicApi):
+    def __init__(
+        self,
+        bitwarden_api: BitwardenPublicApi,
         user_management_api: UserManagementApi,
+    ):
         self.bitwarden_api = bitwarden_api
+        self.user_management_api = user_management_api
 
     def run(self, event: Dict[str, Any]) -> None:
         validate(instance=event, schema=onboard_user_event_schema)
         user_team_membership = self.user_management_api.get_user_teams(username=event["username"])
+        user_id = self.bitwarden_api.invite_user(
             username=event["username"],
             email=event["email"],
+        )
+        existing_groups = self.bitwarden_api.list_existing_groups(user_team_membership)
+        existing_collections = self.bitwarden_api.list_existing_collections(user_team_membership)
+        collections = self.bitwarden_api.list_existing_collections(user_team_membership)
+        group_ids = self.bitwarden_api.collate_user_group_ids(
+            teams=user_team_membership,
+            groups=existing_groups,
+        )
+        self.bitwarden_api.associate_user_to_groups(
+            user_id=user_id,
+            group_ids=group_ids,
         )

--- a/bitwarden_manager/onboard_user.py
+++ b/bitwarden_manager/onboard_user.py
@@ -4,6 +4,7 @@ from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
 
 from jsonschema import validate
 
+from bitwarden_manager.clients.user_management_api import UserManagementApi
 onboard_user_event_schema = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -18,11 +19,12 @@ onboard_user_event_schema = {
 
 class OnboardUser:
     def __init__(self, bitwarden_api: BitwardenPublicApi):
+        user_management_api: UserManagementApi,
         self.bitwarden_api = bitwarden_api
 
     def run(self, event: Dict[str, Any]) -> None:
         validate(instance=event, schema=onboard_user_event_schema)
-        self.bitwarden_api.invite_user(
+        user_team_membership = self.user_management_api.get_user_teams(username=event["username"])
             username=event["username"],
             email=event["email"],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ boto3 = "^1.26.127"
 boto3-stubs = "^1.26.131"
 jsonschema = "^4.17.3"
 types-jsonschema = "^4.17.0.8"
+moto = "^4.1.11"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -29,7 +29,10 @@ def test_invite_user() -> None:
                     }
                 )
             ],
-            body="{}",
+            body=b'{ "type": 0, "accessAll": true, "externalId": null, "resetPasswordEnrolled": true, "object": '
+            b'"member", "id": "XXXXXXXX", "userId": "YYYYYYYY",'
+            b'"name": "John Smith", "email": "jsmith@example.com", '
+            b'"twoFactorEnabled": true, "status": 0, "collections": [] }',
             status=200,
             content_type="application/json",
         )
@@ -39,10 +42,12 @@ def test_invite_user() -> None:
             client_id="foo",
             client_secret="bar",
         )
-        client.invite_user(
+        user_id = client.invite_user(
             username=test_user,
             email=test_email,
         )
+
+        assert user_id == "XXXXXXXX"
 
 
 @responses.activate
@@ -71,6 +76,16 @@ def test_handle_already_invited_user(caplog: LogCaptureFixture) -> None:
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         rsps.add(MOCKED_LOGIN)
         rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/members",
+            body=b'{"data": [ { "type": 0, "accessAll": true, "externalId": "external_id_123456", '
+            b'"resetPasswordEnrolled": true, "object": "member", "id": "XXXXXXXX", '
+            b'"userId": "YYYYYYYY", "name": "test.user", '
+            b'"email": "test@example.com", "twoFactorEnabled": true, "status": 0, "collections": [] } ] }',
+            status=200,
+            content_type="application/json",
+        )
+        rsps.add(
             responses.POST,
             "https://api.bitwarden.com/public/members",
             body=b'{"object":"error","message":"This user has already been invited.","errors":null}',
@@ -90,7 +105,73 @@ def test_handle_already_invited_user(caplog: LogCaptureFixture) -> None:
 
 
 @responses.activate
+def test_handle_already_no_matching_email(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/members",
+            body=b'{"data": [ { "type": 0, "accessAll": true, "externalId": "external_id_123456", '
+            b'"resetPasswordEnrolled": true, "object": "member", "id": "XXXXXXXX", '
+            b'"userId": "YYYYYYYY", "name": "test.user", '
+            b'"email": "test@example.com", "twoFactorEnabled": true, "status": 0, "collections": [] } ] }',
+            status=200,
+            content_type="application/json",
+        )
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/members",
+            body=b'{"object":"error","message":"This user has already been invited.","errors":null}',
+            status=400,
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with caplog.at_level(logging.INFO):
+            client.invite_user(username="test.user", email="no_match@example.com")
+
+        assert "user already invited ignoring error" in caplog.text
+
+
+@responses.activate
+def test_handle_already_invited_http_error(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/members",
+            body=b'{"object":"error","message":"The request\'s model state is invalid."}',
+            status=400,
+            content_type="application/json",
+        )
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/members",
+            body=b'{"object":"error","message":"This user has already been invited.","errors":null}',
+            status=400,
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to retrieve users",
+        ):
+            client.invite_user(username="test.user", email="test@example.com")
+
+
+@responses.activate
 def test_failed_login() -> None:
+    test_user = "test.user"
+    test_email = "test@example.com"
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         rsps.add(
             responses.POST,
@@ -110,7 +191,557 @@ def test_failed_login() -> None:
             Exception,
             match="Failed to authenticate with " "https://identity.bitwarden.com/connect/token, " "creds incorrect?",
         ):
-            client.invite_user(username="test.user", email="test@example.com")
+            client.invite_user(test_user, test_email)
+
+
+@responses.activate
+def test_create_group() -> None:
+    test_group = "Group Name"
+    collection_id = "XXXXXXXX"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/groups",
+            body=b'{"name":"Group Name","accessAll":"false","object":"group","id":"XXXXXXXXX","collections":[]}',
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "name": test_group,
+                        "accessAll": False,
+                        "externalId": test_group,
+                        "collections": [{"id": f"{collection_id}", "readOnly": False}],
+                    }
+                )
+            ],
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        group_id = client.create_group(group_name=test_group, collection_id=collection_id)
+        assert group_id == "XXXXXXXXX"
+
+
+@responses.activate
+def test_invalid_group_name(caplog: LogCaptureFixture) -> None:
+    test_group = ""
+    client = BitwardenPublicApi(
+        logger=logging.getLogger(),
+        client_id="foo",
+        client_secret="bar",
+    )
+
+    with caplog.at_level(logging.INFO):
+        new_group = client.create_group(group_name=test_group, collection_id="XXXXXXXX")
+    assert "Group name invalid" in caplog.text
+
+    assert new_group == ""
+
+
+@responses.activate
+def test_failed_to_create_group() -> None:
+    test_group = "bad group"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/groups",
+            body="",
+            status=400,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to create group",
+        ):
+            client.create_group(group_name=test_group, collection_id="XXXXXX")
+
+
+@responses.activate
+def test_get_collections_failure() -> None:
+    collection_name = "test_name"
+    group_id = "XXXXXXXX"
+    collection_id = "ZZZZZZZZ"
+    with responses.RequestsMock() as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=400,
+            content_type="application/json",
+            method="GET",
+            url=f"https://api.bitwarden.com/public/collections/{collection_id}",
+            json={"externalId": "Team Name One", "object": "collection", "id": collection_id, "groups": []},
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to get collections",
+        ):
+            client.update_collection_groups(
+                collection_name=collection_name, group_id=group_id, collection_id=collection_id
+            )
+
+
+@responses.activate
+def test_get_user_groups_failure() -> None:
+    user_id = "XXXXXXXX"
+    group_ids = ["ZZZZZZZZ"]
+    with responses.RequestsMock() as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=400,
+            content_type="application/json",
+            method="GET",
+            url=f"https://api.bitwarden.com/public/members/{user_id}/group-ids",
+            json={},
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to get user groups",
+        ):
+            client.associate_user_to_groups(user_id=user_id, group_ids=group_ids)
+
+
+@responses.activate
+def test_associate_user_to_group() -> None:
+    test_user_id = "XXXXXXXX"
+    group_ids = ["ZZZZZZZZ"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url=f"https://api.bitwarden.com/public/members/{test_user_id}/group-ids",
+            json=["ZZZZZZZZ", "YYYYYYYY"],
+        )
+        rsps.add(
+            responses.PUT,
+            f"https://api.bitwarden.com/public/members/{test_user_id}/group-ids",
+            body="",
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "groupIds": group_ids,
+                    }
+                )
+            ],
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        client.associate_user_to_groups(user_id=test_user_id, group_ids=group_ids)
+
+
+@responses.activate
+def test_failed_to_associate_user_to_groups() -> None:
+    test_user_id = "XXXXXXXX"
+    group_ids = ["ZZZZZZZZ"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url=f"https://api.bitwarden.com/public/members/{test_user_id}/group-ids",
+            json=["ZZZZZZZZ"],
+        )
+        rsps.add(
+            responses.PUT,
+            f"https://api.bitwarden.com/public/members/{test_user_id}/group-ids",
+            body="",
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "groupIds": group_ids,
+                    }
+                )
+            ],
+            status=400,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to associate user to group-ids",
+        ):
+            client.associate_user_to_groups(user_id=test_user_id, group_ids=group_ids)
+
+
+@responses.activate
+def test_failed_to_update_collection_group() -> None:
+    collection_name = "Team Name One"
+    collection_id = "XXXXXXXX"
+    group_id = "ZZZZZZZZ"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url=f"https://api.bitwarden.com/public/collections/{collection_id}",
+            json={"externalId": "Team Name One", "object": "collection", "id": collection_id, "groups": []},
+        )
+        rsps.add(
+            status=400,
+            content_type="application/json",
+            method="PUT",
+            url=f"https://api.bitwarden.com/public/collections/{collection_id}",
+            json={"externalId": "Team Name One", "object": "collection", "id": collection_id, "groups": []},
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to associate collection to group-ids",
+        ):
+            client.update_collection_groups(
+                collection_name=collection_name, collection_id=collection_id, group_id=group_id
+            )
+
+
+@responses.activate
+def test_list_existing_collections() -> None:
+    teams = ["Team Name One"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url="https://api.bitwarden.com/public/collections",
+            json={
+                "data": [
+                    {
+                        "externalId": "Team Name One",
+                        "object": "collection",
+                        "id": "XXXXXXXX",
+                        "groups": [{"id": "YYYYYYYY", "readOnly": True}],
+                    }
+                ]
+            },
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        collections = client.list_existing_collections(teams)
+
+        assert collections == {"Team Name One": "XXXXXXXX"}
+
+
+@responses.activate
+def test_list_existing_collections_duplicate() -> None:
+    teams = ["Team Name One"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url="https://api.bitwarden.com/public/collections",
+            json={
+                "data": [
+                    {
+                        "externalId": "Team Name One",
+                        "object": "collection",
+                        "id": "XXXXXXXX",
+                        "groups": [{"id": "YYYYYYYY", "readOnly": True}],
+                    },
+                    {
+                        "externalId": "Team Name One",
+                        "object": "collection",
+                        "id": "XXXXXXXX",
+                        "groups": [{"id": "YYYYYYYY", "readOnly": True}],
+                    },
+                ]
+            },
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        collections = client.list_existing_collections(teams)
+
+        assert collections == {"Team Name One": "duplicate"}
+
+
+@responses.activate
+def test_no_matching_collections() -> None:
+    teams = ["Team Name One", "Team Name Two"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url="https://api.bitwarden.com/public/collections",
+            json={
+                "data": [
+                    {
+                        "externalId": "Group Name",
+                        "object": "collection",
+                        "id": "XXXXXXXX",
+                        "groups": [{"id": "YYYYYYYY", "readOnly": True}],
+                    }
+                ]
+            },
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        collections = client.list_existing_collections(teams)
+
+        assert collections == {}
+
+
+@responses.activate
+def test_fail_to_list_collections() -> None:
+    teams = ["Team Name One", "Team Name Two"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=400,
+            content_type="application/json",
+            method="GET",
+            url="https://api.bitwarden.com/public/collections",
+            json={},
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to list collections",
+        ):
+            client.list_existing_collections(teams)
+
+
+@responses.activate
+def test_list_existing_groups() -> None:
+    teams = ["Team Name One", "Team Name Two"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/groups",
+            body=b'{"object":"list","data":[{"object":"group","id":"YYYYYYYY",'
+            b'"collections":[],"name":"Team Name One","accessAll":false,"externalId":null}]}',
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        successful_response = client.list_existing_groups(users_teams=teams)
+
+        assert successful_response == {teams[0]: "YYYYYYYY"}
+
+
+@responses.activate
+def test_list_existing_groups_with_duplicates() -> None:
+    teams = ["Team Name One", "Team Name Two"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/groups",
+            body=b'{"object":"list","data":[{"object":"group","id":"YYYYYYYY",'
+            b'"collections":[],"name":"Team Name One","accessAll":false,"externalId":null},'
+            b'{"object":"group","id":"XXXXXXX","collections":[],'
+            b'"name":"Team Name One","accessAll":false,"externalId":null}]}',
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        successful_response = client.list_existing_groups(users_teams=teams)
+
+        assert successful_response == {teams[0]: "duplicate"}
+
+
+@responses.activate
+def test_failed_to_list_groups() -> None:
+    teams = ["Team Name One", "Team Name Two"]
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/groups",
+            body="",
+            status=400,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to list groups",
+        ):
+            client.list_existing_groups(users_teams=teams)
+
+
+@responses.activate
+def test_collate_user_group_ids() -> None:
+    teams = ["Team Name One", "Team Name Two"]
+    groups = {"Team Name Two": "WWWWWWWW"}
+    collections = {"Team Name One": "ZZZZZZZZ", "Team Name Two": "XXXXXXXX"}
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url="https://api.bitwarden.com/public/collections/ZZZZZZZZ",
+            json={"externalId": "Team Name One", "object": "collection", "id": "ZZZZZZZZ", "groups": []},
+        )
+        rsps.add(
+            status=200,
+            content_type="application/json",
+            method="GET",
+            url="https://api.bitwarden.com/public/collections/XXXXXXXX",
+            json={
+                "externalId": "Team Name Two",
+                "object": "collection",
+                "id": "XXXXXXXX",
+                "groups": [{"id": "WWWWWWWW", "readOnly": False}],
+            },
+        )
+        rsps.add(
+            responses.PUT,
+            "https://api.bitwarden.com/public/collections/ZZZZZZZZ",
+            body="",
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "externalId": "Team Name One",
+                        "groups": [{"id": "YYYYYYYY", "readOnly": False}],
+                    }
+                )
+            ],
+            status=200,
+            content_type="application/json",
+        )
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/groups",
+            body=b'{"name":"Team Name One","externalId":"Team Name One","accessAll":"false",'
+            b'"object":"group","id":"YYYYYYYY",'
+            b'"collections":[{"id":"ZZZZZZZZ", "readOnly": "false"}]}',
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "name": "Team Name One",
+                        "accessAll": False,
+                        "externalId": "Team Name One",
+                        "collections": [{"id": "ZZZZZZZZ", "readOnly": False}],
+                    }
+                )
+            ],
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        successful_response = client.collate_user_group_ids(teams=teams, groups=groups, collections=collections)
+
+        assert successful_response == ["YYYYYYYY", "WWWWWWWW"]
+
+
+@responses.activate
+def test_collate_user_group_ids_duplicates() -> None:
+    teams = ["Team Name One"]
+    groups = {"Team Name One": "duplicate"}
+    collections = {"Team Name One": "ZZZZZZZZ"}
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="There are duplicate groups or collections",
+        ):
+            client.collate_user_group_ids(teams=teams, groups=groups, collections=collections)
 
 
 MOCKED_LOGIN = responses.Response(

--- a/tests/bitwarden_manager/clients/test_user_management_api.py
+++ b/tests/bitwarden_manager/clients/test_user_management_api.py
@@ -1,0 +1,141 @@
+import logging
+
+import pytest
+import responses
+from _pytest.logging import LogCaptureFixture
+
+from bitwarden_manager.clients.user_management_api import UserManagementApi
+
+API_URL = "https://user-management-backend-production.tools.tax.service.gov.uk/v2"
+AUTH_URL = "https://user-management-auth-production.tools.tax.service.gov.uk/v1/login"
+
+
+@responses.activate
+def test_get_user_teams() -> None:
+    test_user = "test.user"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            f"{API_URL}/organisations/users/{test_user}/teams",
+            status=200,
+            content_type="application/json",
+            body=b'{"teams": [{"slack": "https://example.com","team": "Example Team"},'
+            b'{"slack": "https://example.com","team": "Example Team Two"}]}',
+        )
+        client = UserManagementApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        team_list = client.get_user_teams(username=test_user)
+
+        assert team_list == ["Example Team", "Example Team Two"]
+
+
+@responses.activate
+def test_missing_user(caplog: LogCaptureFixture) -> None:
+    missing_user = "missing.user"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            f"{API_URL}/organisations/users/{missing_user}/teams",
+            status=404,
+            content_type="application/json",
+            body=b'{"reason": "Not Found"}',
+        )
+        client = UserManagementApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        with caplog.at_level(logging.INFO):
+            client.get_user_teams(username=missing_user)
+
+        assert "User Not Found" in caplog.text
+
+
+@responses.activate
+def test_failed_to_get_user_teams(caplog: LogCaptureFixture) -> None:
+    missing_user = "missing.user"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            f"{API_URL}/organisations/users/{missing_user}/teams",
+            status=400,
+            content_type="application/json",
+            body=b'{"reason": "Bad Request"}',
+        )
+        client = UserManagementApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to get teams for user",
+        ):
+            client.get_user_teams(username=missing_user)
+
+
+@responses.activate
+def test_invalid_user(caplog: LogCaptureFixture) -> None:
+    invalid_user = "invalid.user!"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            f"{API_URL}/organisations/users/{invalid_user}/teams",
+            status=422,
+            content_type="application/json",
+            body=b'{"reason": "Invalid uid"}',
+        )
+        client = UserManagementApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        with caplog.at_level(logging.INFO):
+            client.get_user_teams(username=invalid_user)
+
+        assert "Invalid User" in caplog.text
+
+
+@responses.activate
+def test_failed_login() -> None:
+    test_user = "test.user"
+    auth_url = "https://user-management-auth-production.tools.tax.service.gov.uk/v1/login"
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(
+            responses.POST,
+            auth_url,
+            body=b'{"reason": "Unauthorised"}',
+            status=401,
+            content_type="application/json",
+        )
+
+        client = UserManagementApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+
+        with pytest.raises(
+            Exception,
+            match="Failed to authenticate with " f"{auth_url}, " "creds incorrect?",
+        ):
+            client.get_user_teams(username=test_user)
+
+
+MOCKED_LOGIN = responses.Response(
+    method="POST",
+    url="https://user-management-auth-production.tools.tax.service.gov.uk/v1/login",
+    status=200,
+    json={
+        "Token": "TEST_BEARER_TOKEN",
+        "uid": "user.name",
+    },
+)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from unittest import mock
 from unittest.mock import patch, Mock
 
@@ -27,7 +28,7 @@ def test_handler_ignores_unknown_events(boto_mock: Mock, caplog: LogCaptureFixtu
 @mock.patch("boto3.client")
 def test_handler_routes_new_user_events(boto_mock: Mock) -> None:
     event = dict(event_name="new_user")
-    with patch.object(OnboardUser, "run") as mock_method:
+    with patch.object(OnboardUser, "run") as mock_method, mock.patch.dict(os.environ, {"ORGANISATION_ID": "abc-123"}):
         handler(event=event, context={})
 
     mock_method.assert_called_once_with(event=event)
@@ -36,7 +37,7 @@ def test_handler_routes_new_user_events(boto_mock: Mock) -> None:
 @mock.patch("boto3.client")
 def test_handler_routes_export_vault_events(boto_mock: Mock) -> None:
     event = dict(event_name="export_vault")
-    with patch.object(ExportVault, "run") as mock_method:
+    with patch.object(ExportVault, "run") as mock_method, mock.patch.dict(os.environ, {"ORGANISATION_ID": "abc-123"}):
         handler(event=event, context={})
 
     mock_method.assert_called_once_with(event=event)

--- a/tests/test_export_vault.py
+++ b/tests/test_export_vault.py
@@ -6,7 +6,7 @@ from bitwarden_manager.export_vault import ExportVault
 from unittest.mock import Mock, MagicMock
 
 
-@mock.patch.dict(os.environ, {"BITWARDEN_BACKUP_BUCKET": "test-bucket", "ORGANISATION_ID": "abc-123"})
+@mock.patch.dict(os.environ, {"BITWARDEN_BACKUP_BUCKET": "test-bucket"})
 def test_export_vault() -> None:
     event = {"event_name": "export_vault"}
     filepath = "test.json"
@@ -15,6 +15,5 @@ def test_export_vault() -> None:
 
     ExportVault(bitwarden_vault_client=mock_client).run(event)
 
-    mock_client.export_vault.assert_called_with(org_id="abc-123")
     mock_client.write_file_to_s3.assert_called_with("test-bucket", filepath)
     assert mock_client.logout.called

--- a/tests/test_onboard_user.py
+++ b/tests/test_onboard_user.py
@@ -1,17 +1,20 @@
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 import pytest
 from jsonschema.exceptions import ValidationError
 
 from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
 from bitwarden_manager.onboard_user import OnboardUser
+from bitwarden_manager.clients.user_management_api import UserManagementApi
 
 
 def test_onboard_user_invites_user_to_org() -> None:
     event = {"event_name": "new_user", "username": "test.user", "email": "testemail@example.com"}
     mock_client = Mock(spec=BitwardenPublicApi)
+    mock_client_user_management = MagicMock(spec=UserManagementApi)
 
     OnboardUser(bitwarden_api=mock_client).run(event)
+        user_management_api=mock_client_user_management,
 
     mock_client.invite_user.assert_called_with(username="test.user", email="testemail@example.com")
 
@@ -19,9 +22,11 @@ def test_onboard_user_invites_user_to_org() -> None:
 def test_onboard_user_rejects_bad_events() -> None:
     event = {"somthing?": 1}
     mock_client = Mock(spec=BitwardenPublicApi)
+    mock_client_user_management = MagicMock(spec=UserManagementApi)
 
     with pytest.raises(ValidationError, match="'event_name' is a required property"):
         OnboardUser(bitwarden_api=mock_client).run(event)
+            user_management_api=mock_client_user_management,
 
     assert not mock_client.invite_user.called
 
@@ -29,8 +34,10 @@ def test_onboard_user_rejects_bad_events() -> None:
 def test_onboard_user_rejects_bad_emails() -> None:
     event = {"event_name": "new_user", "username": "test.user", "email": "not_an_email"}
     mock_client = Mock(spec=BitwardenPublicApi)
+    mock_client_user_management = MagicMock(spec=UserManagementApi)
 
     with pytest.raises(ValidationError):
         OnboardUser(bitwarden_api=mock_client).run(event)
+            user_management_api=mock_client_user_management,
 
     assert not mock_client.invite_user.called

--- a/tests/test_onboard_user.py
+++ b/tests/test_onboard_user.py
@@ -6,16 +6,19 @@ from jsonschema.exceptions import ValidationError
 from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
 from bitwarden_manager.onboard_user import OnboardUser
 from bitwarden_manager.clients.user_management_api import UserManagementApi
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
 
 
 def test_onboard_user_invites_user_to_org() -> None:
     event = {"event_name": "new_user", "username": "test.user", "email": "testemail@example.com"}
     mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_user_management = MagicMock(spec=UserManagementApi)
+    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
 
     OnboardUser(
         bitwarden_api=mock_client_bitwarden,
         user_management_api=mock_client_user_management,
+        bitwarden_vault_client=mock_client_bitwarden_vault,
     ).run(event)
 
     mock_client_bitwarden.invite_user.assert_called_with(username="test.user", email="testemail@example.com")
@@ -25,11 +28,13 @@ def test_onboard_user_rejects_bad_events() -> None:
     event = {"somthing?": 1}
     mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_user_management = MagicMock(spec=UserManagementApi)
+    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
 
     with pytest.raises(ValidationError, match="'event_name' is a required property"):
         OnboardUser(
             bitwarden_api=mock_client_bitwarden,
             user_management_api=mock_client_user_management,
+            bitwarden_vault_client=mock_client_bitwarden_vault,
         ).run(event)
 
     assert not mock_client_bitwarden.invite_user.called
@@ -39,11 +44,13 @@ def test_onboard_user_rejects_bad_emails() -> None:
     event = {"event_name": "new_user", "username": "test.user", "email": "not_an_email"}
     mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_user_management = MagicMock(spec=UserManagementApi)
+    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
 
     with pytest.raises(ValidationError):
         OnboardUser(
             bitwarden_api=mock_client_bitwarden,
             user_management_api=mock_client_user_management,
+            bitwarden_vault_client=mock_client_bitwarden_vault,
         ).run(event)
 
     assert not mock_client_bitwarden.invite_user.called

--- a/tests/test_onboard_user.py
+++ b/tests/test_onboard_user.py
@@ -10,34 +10,40 @@ from bitwarden_manager.clients.user_management_api import UserManagementApi
 
 def test_onboard_user_invites_user_to_org() -> None:
     event = {"event_name": "new_user", "username": "test.user", "email": "testemail@example.com"}
-    mock_client = Mock(spec=BitwardenPublicApi)
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_user_management = MagicMock(spec=UserManagementApi)
 
-    OnboardUser(bitwarden_api=mock_client).run(event)
+    OnboardUser(
+        bitwarden_api=mock_client_bitwarden,
         user_management_api=mock_client_user_management,
+    ).run(event)
 
-    mock_client.invite_user.assert_called_with(username="test.user", email="testemail@example.com")
+    mock_client_bitwarden.invite_user.assert_called_with(username="test.user", email="testemail@example.com")
 
 
 def test_onboard_user_rejects_bad_events() -> None:
     event = {"somthing?": 1}
-    mock_client = Mock(spec=BitwardenPublicApi)
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_user_management = MagicMock(spec=UserManagementApi)
 
     with pytest.raises(ValidationError, match="'event_name' is a required property"):
-        OnboardUser(bitwarden_api=mock_client).run(event)
+        OnboardUser(
+            bitwarden_api=mock_client_bitwarden,
             user_management_api=mock_client_user_management,
+        ).run(event)
 
-    assert not mock_client.invite_user.called
+    assert not mock_client_bitwarden.invite_user.called
 
 
 def test_onboard_user_rejects_bad_emails() -> None:
     event = {"event_name": "new_user", "username": "test.user", "email": "not_an_email"}
-    mock_client = Mock(spec=BitwardenPublicApi)
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_user_management = MagicMock(spec=UserManagementApi)
 
     with pytest.raises(ValidationError):
-        OnboardUser(bitwarden_api=mock_client).run(event)
+        OnboardUser(
+            bitwarden_api=mock_client_bitwarden,
             user_management_api=mock_client_user_management,
+        ).run(event)
 
-    assert not mock_client.invite_user.called
+    assert not mock_client_bitwarden.invite_user.called


### PR DESCRIPTION
## What
* Create group/collection based on team membership within User Management portal
* Enroll newly invited user/existing user to new/existing collection based on said membership
* When duplicate groups/collections encountered, don't proceed
* Only invite user if they exist in UMP

## Why
* Ease enrolment of user to appropriate teams
* Create consistency by using UMP as source of truth for group membership
* Simplify onboarding

## Additional
* Tests added as standard, CI checks passing, local testing performed. Additional testing in development to ensure no connectivity issues to UMP in addition to successful authentication/authorisation once connected
```
---------- coverage: platform linux, python 3.11.3-final-0 -----------
Name                                                     Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------
bitwarden_manager/__init__.py                                0      0   100%
bitwarden_manager/bitwarden_manager.py                      47      0   100%
bitwarden_manager/clients/__init__.py                        0      0   100%
bitwarden_manager/clients/aws_secretsmanager_client.py      12      0   100%
bitwarden_manager/clients/bitwarden_public_api.py          140      0   100%
bitwarden_manager/clients/bitwarden_vault_client.py         79      0   100%
bitwarden_manager/clients/user_management_api.py            37      0   100%
bitwarden_manager/export_vault.py                           11      0   100%
bitwarden_manager/onboard_user.py                           21      0   100%
bitwarden_manager/redacting_formatter.py                    20      0   100%
--------------------------------------------------------------------------------------
TOTAL                                                      367      0   100%

Required test coverage of 100% reached. Total coverage: 100.00%

============================== 56 passed in 1.35s ==============================
All done! ✨ 🍰 ✨
23 files would be left unchanged.
Success: no issues found in 23 source files
[tester]        WARNING nosec encountered (B108), but no failed test on line 69
d2d561bf2464: Exists 
e5b67a8f9568: Exists 
docker.io/zemanlx/remark-lint:0.2.0
README.md: no issues found
scripts/events-log-parser/README.md: no issues found
```