### PR TITLE
PSEC-1897 Handle user confirmation for allowed domains

### DIFF
--- a/bitwarden_manager/bitwarden_manager.py
+++ b/bitwarden_manager/bitwarden_manager.py
@@ -9,6 +9,7 @@ from bitwarden_manager.clients.s3_client import S3Client
 from bitwarden_manager.clients.user_management_api import UserManagementApi
 from bitwarden_manager.onboard_user import OnboardUser
 from bitwarden_manager.export_vault import ExportVault
+from bitwarden_manager.confirm_user import ConfirmUser
 from bitwarden_manager.redacting_formatter import get_bitwarden_logger
 
 
@@ -34,6 +35,9 @@ class BitwardenManager:
             case "export_vault":
                 self.__logger.debug("handling event with ExportVault")
                 ExportVault(bitwarden_vault_client=bitwarden_vault_client, s3_client=S3Client()).run(event=event)
+            case "confirm_user":
+                self.__logger.debug("handling event with ConfirmUser")
+                ConfirmUser(bitwarden_vault_client=bitwarden_vault_client).run(event=event)
             case _:
                 self.__logger.info(f"ignoring unknown event '{event_name}'")
         bitwarden_vault_client.logout()

--- a/bitwarden_manager/confirm_user.py
+++ b/bitwarden_manager/confirm_user.py
@@ -1,0 +1,37 @@
+from typing import Dict, Any
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient, BitwardenVaultClientError
+from jsonschema import validate
+
+confirm_user_event_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "event_name": {"type": "string", "description": "name of the current event", "pattern": "confirm_user"},
+        "allowed_domains": {"type": "array", "description": "approved domains that can be automatically confirmed"},
+    },
+    "required": ["event_name", "allowed_domains"],
+}
+
+
+class ConfirmUser:
+    def __init__(self, bitwarden_vault_client: BitwardenVaultClient):
+        self.bitwarden_vault_client = bitwarden_vault_client
+
+    def run(self, event: Dict[str, Any]) -> None:
+        validate(instance=event, schema=confirm_user_event_schema)
+        unconfirmed_users = self.bitwarden_vault_client.list_unconfirmed_users()
+        self.confirm_valid_users(unconfirmed_users, event["allowed_domains"])
+
+    def confirm_valid_users(self, unconfirmed_users: list[Dict[str, str]], allowed_domains: list[str]) -> None:
+        errors = []
+        for user in unconfirmed_users:
+            user_email = user["email"]
+            user_id = user["id"]
+
+            if user_email.split("@")[1] in allowed_domains:
+                try:
+                    self.bitwarden_vault_client.confirm_user(user_id)
+                except BitwardenVaultClientError as e:
+                    errors.append(e)
+        if errors:
+            raise BitwardenVaultClientError(f"Confirmation process failed on {len(errors)} users")

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -147,3 +147,27 @@ def test_no_missing_collections(client: BitwardenVaultClient, caplog: LogCapture
     with caplog.at_level(logging.INFO):
         client.create_collection(teams, existing_collections)
     assert "No missing collections found" in caplog.text
+
+
+def test_list_org_users(client: BitwardenVaultClient) -> None:
+    unconfirmed_users = client.list_unconfirmed_users()
+    assert isinstance(unconfirmed_users, list)
+    assert isinstance(unconfirmed_users[0], dict)
+    assert isinstance(unconfirmed_users[0]["id"], str)
+    assert isinstance(unconfirmed_users[0]["email"], str)
+
+
+def test_list_org_users_failed(failing_client: BitwardenVaultClient) -> None:
+    with pytest.raises(BitwardenVaultClientError, match="'list', 'org-members'"):
+        failing_client.list_unconfirmed_users()
+
+
+def test_confirm_user(client: BitwardenVaultClient, caplog: LogCaptureFixture) -> None:
+    with caplog.at_level(logging.DEBUG):
+        client.confirm_user(user_id="example_id")
+    assert "User example_id confirmed successfully" in caplog.text
+
+
+def test_confirm_user_failed_to_parse(failing_client: BitwardenVaultClient) -> None:
+    with pytest.raises(BitwardenVaultClientError, match="'confirm', 'org-member'"):
+        failing_client.confirm_user(user_id="example_id")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,6 +10,7 @@ from bitwarden_manager.clients.aws_secretsmanager_client import AwsSecretsManage
 from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
 from bitwarden_manager.onboard_user import OnboardUser
 from bitwarden_manager.export_vault import ExportVault
+from bitwarden_manager.confirm_user import ConfirmUser
 
 
 @mock.patch("boto3.client")
@@ -67,10 +68,14 @@ def test_handler_routes_export_vault_events(_: Mock) -> None:
     bitwarden_logout.assert_called_once()
 
 
-# @mock.patch("boto3.client")
-# def test_handler_routes_confirm_user(boto_mock: Mock) -> None:
-#     event = dict(event_name="confirm_user")
-#     with patch.object(ConfirmUser, "run") as confirm_user_mock:
-#         handler(event=event, context={})
-#
-#     confirm_user_mock.assert_called_once_with(event=event)
+@mock.patch("boto3.client")
+def test_handler_routes_confirm_user(_: Mock) -> None:
+    event = dict(event_name="confirm_user", allowed_domains=["example.co.uk"])
+    with patch.object(AwsSecretsManagerClient, "get_secret_value") as secrets_manager_mock:
+        secrets_manager_mock.return_value = "23497858247589473589734805734853"
+        with patch.object(BitwardenVaultClient, "logout") as bitwarden_logout:
+            with patch.object(ConfirmUser, "run") as confirm_user_mock:
+                handler(event=event, context={})
+
+    confirm_user_mock.assert_called_once_with(event=event)
+    bitwarden_logout.assert_called_once()

--- a/tests/test_confirm_user.py
+++ b/tests/test_confirm_user.py
@@ -1,0 +1,67 @@
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient, BitwardenVaultClientError
+from bitwarden_manager.confirm_user import ConfirmUser
+from unittest.mock import Mock, MagicMock
+from jsonschema.exceptions import ValidationError
+
+
+def test_list_users() -> None:
+    event = {"event_name": "confirm_user", "allowed_domains": ["example.co.uk"]}
+    mock_client = MagicMock(spec=BitwardenVaultClient)
+    ConfirmUser(bitwarden_vault_client=mock_client).run(event)
+
+    assert mock_client.list_unconfirmed_users.called
+
+
+def test_confirm_user() -> None:
+    event = {"event_name": "confirm_user", "allowed_domains": ["example.co.uk"]}
+    mock_client = MagicMock(spec=BitwardenVaultClient)
+
+    mock_client.list_unconfirmed_users = MagicMock(return_value=[{"email": "test@example.co.uk", "id": "example_id"}])
+    ConfirmUser(bitwarden_vault_client=mock_client).run(event)
+
+    assert mock_client.confirm_user.called
+
+
+def test_confirm_user_invalid_domain() -> None:
+    event = {"event_name": "confirm_user", "allowed_domains": ["example.co.uk"]}
+    mock_client = MagicMock(spec=BitwardenVaultClient)
+
+    mock_client.list_unconfirmed_users = MagicMock(
+        return_value=[{"email": "test@invaliddomain.co.uk", "id": "example_id"}]
+    )
+    ConfirmUser(bitwarden_vault_client=mock_client).run(event)
+
+    assert mock_client.confirm_user.not_called
+
+
+def test_confirm_user_handles_errors(caplog: LogCaptureFixture) -> None:
+    event = {"event_name": "confirm_user", "allowed_domains": ["example.co.uk"]}
+    mock_client = MagicMock(spec=BitwardenVaultClient)
+
+    mock_client.list_unconfirmed_users = MagicMock(
+        return_value=[
+            {"email": "test@example.co.uk", "id": "example_id"},
+            {"email": "test2@example.co.uk", "id": "example_id2"},
+            {"email": "test3@invalidexample.co.uk", "id": "example_id2"},
+        ]
+    )
+
+    mock_client.confirm_user = MagicMock(side_effect=BitwardenVaultClientError())
+
+    with pytest.raises(BitwardenVaultClientError, match="Confirmation process failed"):
+        ConfirmUser(bitwarden_vault_client=mock_client).run(event)
+
+    assert mock_client.confirm_user.call_count == 2
+
+
+def test_confirm_user_validates_events() -> None:
+    event = {"event_name": "confirm_user", "allowed_domains": "example.com"}
+    mock_client = Mock(spec=BitwardenVaultClient)
+
+    with pytest.raises(ValidationError, match="'example.com' is not of type 'array'"):
+        ConfirmUser(bitwarden_vault_client=mock_client).run(event)
+
+    assert not mock_client.confirm_user.called


### PR DESCRIPTION
## What
* Confirm users that are invited & have accepted if they have the allowed domains in their emails

## Why
* This additional step for appropriate domains is currently handled via email. The verification required is similar, all non allowed domains still require this normal process 