### PR TITLE
PSEC-1897 pass allowed domain via env var

### DIFF
--- a/bitwarden_manager/redacting_formatter.py
+++ b/bitwarden_manager/redacting_formatter.py
@@ -15,7 +15,9 @@ class RedactingFormatter(logging.Filter):
     @staticmethod
     def validate_patterns(patterns_list: List[str]) -> None:
         for pattern in patterns_list:
-            if pattern == "":
+            if not isinstance(pattern, str):
+                raise ValueError("Patterns must be of type string")
+            elif pattern == "":
                 raise ValueError("Empty string as a pattern is not allowed as this will match and redact all log lines")
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/tests/bitwarden_manager/test_bitwarden_manager.py
+++ b/tests/bitwarden_manager/test_bitwarden_manager.py
@@ -1,7 +1,10 @@
+import os
 from unittest import mock
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
+
 
 from bitwarden_manager.bitwarden_manager import BitwardenManager
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
 
 
 @mock.patch("boto3.client")
@@ -61,3 +64,50 @@ def test_get_bitwarden_vault_creds(mock_secretsmanager: Mock) -> None:
             call(SecretId="/bitwarden/export-encryption-password"),
         ]
     )
+
+
+@mock.patch.dict(os.environ, {"ALLOWED_DOMAINS": "example.com"})
+@mock.patch("boto3.client")
+def test_confirm_user_passed_allowed_domains(mock_secretsmanager: Mock) -> None:
+    get_secret_value = Mock(return_value={"SecretString": "secret"})
+    mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
+
+    bitwarden_mock = Mock(
+        spec=BitwardenVaultClient,
+        list_unconfirmed_users=Mock(
+            return_value=[dict(email="test@example.com", id=111), dict(email="test@evil.com", id=222)]
+        ),
+    )
+    with patch.object(BitwardenManager, "_get_bitwarden_vault_client") as _get_bitwarden_vault_client:
+        _get_bitwarden_vault_client.return_value = bitwarden_mock
+
+        manager = BitwardenManager()
+        manager.run(event={"event_name": "confirm_user"})
+
+    bitwarden_mock.confirm_user.assert_called_once_with(user_id=111)
+
+
+@mock.patch("boto3.client")
+def test_get_allowed_domains_retuns_empty_list_of_domains(mock_secretsmanager: Mock) -> None:
+    get_secret_value = Mock(return_value={"SecretString": "secret"})
+    mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
+
+    assert BitwardenManager()._get_allowed_email_domains() == []
+
+
+@mock.patch.dict(os.environ, {"ALLOWED_DOMAINS": "example.com,foo.com"})
+@mock.patch("boto3.client")
+def test_get_allowed_domains_retuns_list_of_domains_from_string(mock_secretsmanager: Mock) -> None:
+    get_secret_value = Mock(return_value={"SecretString": "secret"})
+    mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
+
+    assert BitwardenManager()._get_allowed_email_domains() == ["example.com", "foo.com"]
+
+
+@mock.patch.dict(os.environ, {"ALLOWED_DOMAINS": " example.com, foo.com  "})
+@mock.patch("boto3.client")
+def test_get_allowed_domains_handles_whitespace(mock_secretsmanager: Mock) -> None:
+    get_secret_value = Mock(return_value={"SecretString": "secret"})
+    mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
+
+    assert BitwardenManager()._get_allowed_email_domains() == ["example.com", "foo.com"]

--- a/tests/bitwarden_manager/test_redacting_formatter.py
+++ b/tests/bitwarden_manager/test_redacting_formatter.py
@@ -46,6 +46,18 @@ def test_get_bitwarden_logger_empty_string_should_error(caplog: LogCaptureFixtur
         get_bitwarden_logger(extra_redaction_patterns=[""])
 
 
+def test_get_redacting_formater_errors_on_non_string_input(caplog: LogCaptureFixture) -> None:
+    with pytest.raises(ValueError, match="Patterns must be of type string"):
+        get_bitwarden_logger(extra_redaction_patterns=[12])  # type: ignore
+
+    get_bitwarden_logger(extra_redaction_patterns=[r"organization.[\w-]{36}"])
+
+    class TestStringClass(str):
+        pass
+
+    get_bitwarden_logger(extra_redaction_patterns=[TestStringClass("foo")])
+
+
 def test_get_bitwarden_logger_override_with_env_var(monkeypatch: MonkeyPatch) -> None:
     assert get_bitwarden_logger(extra_redaction_patterns=[]).getEffectiveLevel() == logging.INFO
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -70,7 +70,7 @@ def test_handler_routes_export_vault_events(_: Mock) -> None:
 
 @mock.patch("boto3.client")
 def test_handler_routes_confirm_user(_: Mock) -> None:
-    event = dict(event_name="confirm_user", allowed_domains=["example.co.uk"])
+    event = dict(event_name="confirm_user")
     with patch.object(AwsSecretsManagerClient, "get_secret_value") as secrets_manager_mock:
         secrets_manager_mock.return_value = "23497858247589473589734805734853"
         with patch.object(BitwardenVaultClient, "logout") as bitwarden_logout:


### PR DESCRIPTION
## What
* Use environment variable to pass allowed_domains list to lambda

## Why
* Gives us control over restrictions while events can pass confirmation through without needing to set/ability to set this