### PR TITLE
PSEC-1947: Don't add users to manually created groups or collection

### DIFF
--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -45,8 +45,8 @@ class BitwardenPublicApi:
         except HTTPError as error:
             raise Exception("Failed to get collections", response.content, error) from error
         external_id: str = response.json().get("externalId")
-        # All groups created by automation have an external id. Manually created
-        # groups _may_ have an external id but we assume that in general they don't
+        # All collections created by automation have an external id. Manually created
+        # collections _may_ have an external id but we assume that in general they don't
         return not bool(external_id and external_id.strip())
 
     def __fetch_user_id(self, email: str) -> str:

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -27,6 +27,17 @@ class BitwardenPublicApi:
         response_list: List[str] = response.json()
         return response_list
 
+    def __group_manually_created(self, group_id: str) -> bool:
+        response = session.get(f"{API_URL}/groups/{group_id}")
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to get group", response.content, error) from error
+        external_id: str = response.json().get("externalId")
+        # All groups created by automation have an external id. Manually created
+        # groups _may_ have an external id but we assume that in general they don't
+        return not bool(external_id and external_id.strip())
+
     def __fetch_user_id(self, email: str) -> str:
         response = session.get(f"{API_URL}/members")
         try:
@@ -141,18 +152,20 @@ class BitwardenPublicApi:
 
     def associate_user_to_groups(self, user_id: str, group_ids: List[str]) -> None:
         existing_user_group_ids = self.__get_user_groups(user_id)
-        for existing_group_id in existing_user_group_ids:
-            if existing_group_id not in group_ids:
-                group_ids.append(existing_group_id)
-        response = session.put(
-            f"{API_URL}/members/{user_id}/group-ids",
-            json={"groupIds": group_ids},
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        try:
-            response.raise_for_status()
-        except HTTPError as error:
-            raise Exception("Failed to associate user to group-ids", response.content, error) from error
+        user_group_ids = existing_user_group_ids[:]
+        for group_id in group_ids:
+            if group_id not in user_group_ids and not self.__group_manually_created(group_id):
+                user_group_ids.append(group_id)
+        if not existing_user_group_ids == user_group_ids:
+            response = session.put(
+                f"{API_URL}/members/{user_id}/group-ids",
+                json={"groupIds": user_group_ids},
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            try:
+                response.raise_for_status()
+            except HTTPError as error:
+                raise Exception("Failed to associate user to group-ids", response.content, error) from error
 
     def update_collection_groups(self, collection_name: str, collection_id: str, group_id: str) -> None:
         group_ids = self.__get_collection_groups(collection_id)

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -33,10 +33,10 @@ class BitwardenPublicApi:
             response.raise_for_status()
         except HTTPError as error:
             raise Exception("Failed to get group", response.content, error) from error
-        external_id: str = response.json().get("externalId")
+        external_id: str = response.json().get("externalId", "")
         # All groups created by automation have an external id. Manually created
         # groups _may_ have an external id but we assume that in general they don't
-        return not bool(external_id and external_id.strip())
+        return not bool(external_id.strip())
 
     def __collection_manually_created(self, collection_id: str) -> bool:
         response = session.get(f"{API_URL}/collections/{collection_id}")
@@ -44,10 +44,10 @@ class BitwardenPublicApi:
             response.raise_for_status()
         except HTTPError as error:
             raise Exception("Failed to get collections", response.content, error) from error
-        external_id: str = response.json().get("externalId")
+        external_id: str = response.json().get("externalId", "")
         # All collections created by automation have an external id. Manually created
         # collections _may_ have an external id but we assume that in general they don't
-        return not bool(external_id and external_id.strip())
+        return not bool(external_id.strip())
 
     def __fetch_user_id(self, email: str) -> str:
         response = session.get(f"{API_URL}/members")


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/PSEC-1947

This PR uses the existence of an external ID as a proxy for whether a group or collection was created by the automation (will always have an external id) or manually (probably usually won't).

- [x] Users are not added to groups that were manually created
- [x] Groups are not added to collections that were manually created