### PR TITLE
PSEC-1962-exclude-manually-created-entities

### DIFF
--- a/bitwarden_manager/temp/external_id_updater.py
+++ b/bitwarden_manager/temp/external_id_updater.py
@@ -14,6 +14,7 @@ UMP_API_URL = "https://user-management-backend-production.tools.tax.service.gov.
 BITWARDEN_API_URL = "https://api.bitwarden.com/public"
 REQUEST_TIMEOUT_SECONDS = 10
 
+
 def get_logger() -> logging.Logger:
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)

--- a/bitwarden_manager/temp/external_id_updater.py
+++ b/bitwarden_manager/temp/external_id_updater.py
@@ -8,11 +8,11 @@ import os
 from typing import Any, Dict, List
 from requests import HTTPError, get
 from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi, session
-from bitwarden_manager.clients.user_management_api import REQUEST_TIMEOUT_SECONDS, UserManagementApi
+from bitwarden_manager.clients.user_management_api import UserManagementApi
 
 UMP_API_URL = "https://user-management-backend-production.tools.tax.service.gov.uk/v2"
 BITWARDEN_API_URL = "https://api.bitwarden.com/public"
-
+REQUEST_TIMEOUT_SECONDS = 10
 
 def get_logger() -> logging.Logger:
     logger = logging.getLogger()
@@ -58,10 +58,9 @@ class Config:
         return self.get_env_var("BITWARDEN_CLIENT_SECRET")
 
 
-class CollectionUpdater:
+class UmpApi:
     def __init__(self) -> None:
         self.config = Config()
-        self.bitwarden_api = self.config.get_bitwarden_public_api()
         self.user_management_api = self.config.get_user_management_api()
 
     def get_teams(self) -> List[str]:
@@ -82,6 +81,12 @@ class CollectionUpdater:
             raise Exception("Failed to get teams", response.content, e) from e
         response_json: Dict[str, Any] = response.json()
         return [t.get("team") for t in response_json.get("teams", [])]
+
+
+class CollectionUpdater:
+    def __init__(self) -> None:
+        self.config = Config()
+        self.bitwarden_api = self.config.get_bitwarden_public_api()
 
     def update_collection_external_id(self, collection_id: str, external_id: str) -> None:
         self.bitwarden_api._BitwardenPublicApi__fetch_token()  # type: ignore
@@ -106,7 +111,7 @@ class CollectionUpdater:
         except (UnicodeDecodeError, binascii.Error):
             return ""
 
-    def collections_with_unencoded_external_id(
+    def ump_team_named_collections_with_unencoded_external_id(
         self, collections: List[Dict[str, Any]], teams: List[str]
     ) -> List[Dict[str, Any]]:
         return [
@@ -114,14 +119,15 @@ class CollectionUpdater:
             for collection in collections
             if collection.get("externalId", "")
             and not self.base64_safe_decode(collection.get("externalId", "")) in teams
+            and collection.get("externalId", "") in teams
         ]
 
     def run(self) -> None:
         self.bitwarden_api._BitwardenPublicApi__fetch_token()  # type: ignore
         collections = self.bitwarden_api._BitwardenPublicApi__list_collections()  # type: ignore
-        teams = self.get_teams()
+        teams = UmpApi().get_teams()
 
-        for collection in self.collections_with_unencoded_external_id(collections, teams):
+        for collection in self.ump_team_named_collections_with_unencoded_external_id(collections, teams):
             collection_id = collection.get("id", "")
             external_id = collection.get("externalId", "")
             if external_id:
@@ -133,13 +139,18 @@ class CollectionUpdater:
 
     def setup(self) -> None:  # pragma: no cover
         # For testing only
+        collections = [
+            {"id": "be5cdb75-d676-463d-89b3-b08a00d54b1e", "externalId": "Platform Security"},
+            {"id": "3a092620-ecdf-46ed-ab1a-b0dc00de9d7e", "externalId": "AWS Account Authorisers"},
+            {"id": "b2b0a7dc-dac8-4077-9b12-b0dd00c865dd", "externalId": "MDTP Apprentices"},
+            {"id": "7cea4408-aa41-469a-a0cb-b08900f6734b", "externalId": "MDTP Platform Pen Testers"},
+            {"id": "f4565a6d-88e2-45ea-bb07-b0eb00b588cc", "externalId": "SomeTestCollection"},
+            {"id": "c955f5b3-c205-4fc8-b4cd-b0eb00c9f737", "externalId": "PSEC-1962 Manually Created"},
+        ]
+        # For testing only
         logger.info("Setting up collections with unencoded external id for testing")
-        self.update_collection_external_id(
-            collection_id="3a092620-ecdf-46ed-ab1a-b0dc00de9d7e", external_id="AWS Account Authorisers"
-        )
-        self.update_collection_external_id(
-            collection_id="b2b0a7dc-dac8-4077-9b12-b0dd00c865dd", external_id="MDTP Apprentices"
-        )
+        for collection in collections:
+            self.update_collection_external_id(collection_id=collection["id"], external_id=collection["externalId"])
 
 
 class GroupUpdater:
@@ -158,6 +169,9 @@ class GroupUpdater:
 
     def has_base64_encoded_external_id(self, group: Dict[str, Any]) -> bool:
         return group.get("externalId") == self.bitwarden_api.external_id_base64_encoded(group.get("name", ""))
+
+    def is_a_ump_team(self, group: Dict[str, Any], teams: List[str]) -> bool:
+        return group.get("name") in teams
 
     def update_group_external_id(self, group: Dict[str, Any], external_id: str = "") -> None:
         group_id = group.get("id")
@@ -183,9 +197,10 @@ class GroupUpdater:
 
     def run(self) -> None:
         self.bitwarden_api._BitwardenPublicApi__fetch_token()  # type: ignore
+        teams = UmpApi().get_teams()
 
         for group in self.get_groups():
-            if not self.has_base64_encoded_external_id(group):
+            if self.is_a_ump_team(group, teams) and not self.has_base64_encoded_external_id(group):
                 self.update_group_external_id(group)
                 logger.info(f"Updated external id of group {group.get('name')}")
 
@@ -195,7 +210,17 @@ class GroupUpdater:
         logger.info("Setting up groups with unencoded external id for testing")
 
         # For testing only
-        teams = ["Platform Security", "Telemetry"]
+        teams = [
+            "AWS Account Authorisers",
+            "Design Resources",
+            "MDTP Apprentices",
+            "MDTP Platform Pen Testers",
+            "WebOps",
+            "Platform Security",
+            "Telemetry",
+            "Test Org admins",
+            "Test org non admins",
+        ]
         for n in teams:
             for g in self.get_groups():
                 if n == g.get("name"):


### PR DESCRIPTION
Ensure external id of manually created groups and collections are not updated