### PR TITLE
PSEC-2027: Enable inviting users with the Bitwarden Manager role

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Subsequently, a group & collection is associated per corresponding team to the n
 The user is granted `edit` privileges on the group/collection they're assigned to.
 More information regarding access control can be found here [Bitwarden Access Control](https://bitwarden.com/help/user-types-access-control/#permissions)
 
-`team_admin` is optional. Omitting or setting it to `false` will invite the user as a `Regular User` while setting it to `true` will invite them as a `Manager`. See https://bitwarden.com/help/user-types-access-control/ for more information on role permissions in Bitwarden.
+`team_admin` is optional. Omitting or setting it to `false` will invite the user as a `Regular User` while setting it 
+to `true` will invite them as a `Manager`. See https://bitwarden.com/help/user-types-access-control/ for more 
+information on role permissions in Bitwarden.
 
 ### Remove user
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ If the user already exists within BitWarden then the lambda will log this.
 {
     "event_name": "new_user",
     "username": "test.user01",
-    "email": "test.user01@example.com"
+    "email": "test.user01@example.com",
+    "team_admin": false
 }
 ```
 
@@ -25,6 +26,8 @@ This passes the `username` to the user-management portal (an internal API) which
 Subsequently, a group & collection is associated per corresponding team to the new user within BitWarden.
 The user is granted `edit` privileges on the group/collection they're assigned to.
 More information regarding access control can be found here [Bitwarden Access Control](https://bitwarden.com/help/user-types-access-control/#permissions)
+
+`team_admin` is optional. Omitting or setting it to `false` will invite the user as a `Regular User` while setting it to `true` will invite them as a `Manager`. See https://bitwarden.com/help/user-types-access-control/ for more information on role permissions in Bitwarden.
 
 ### Remove user
 

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -1,10 +1,21 @@
 import base64
+from enum import IntEnum
 from logging import Logger
 from typing import Dict, List, Any, Optional
 
 from requests import HTTPError, Session
 
-REGULAR_USER = 2
+
+# Bitwarden server enum definition:
+# https://github.com/bitwarden/server/blob/main/src/Core/AdminConsole/Enums/OrganizationUserType.cs
+class UserType(IntEnum):
+    OWNER = 0
+    ADMIN = 1
+    REGULAR_USER = 2
+    MANAGER = 3
+    CUSTOM = 4
+
+
 REQUEST_TIMEOUT_SECONDS = 30
 
 LOGIN_URL = "https://identity.bitwarden.com/connect/token"
@@ -122,12 +133,12 @@ class BitwardenPublicApi:
         except HTTPError as error:
             raise Exception("Failed to list collections", response.content, error) from error
 
-    def invite_user(self, username: str, email: str) -> str:
+    def invite_user(self, username: str, email: str, type: UserType = UserType.REGULAR_USER) -> str:
         self.__fetch_token()
         response = session.post(
             f"{API_URL}/members",
             json={
-                "type": REGULAR_USER,
+                "type": type,
                 "accessAll": False,
                 "resetPasswordEnrolled": True,
                 "externalId": username,

--- a/tests/bitwarden_manager/test_onboard_user.py
+++ b/tests/bitwarden_manager/test_onboard_user.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from jsonschema.exceptions import ValidationError
 
-from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
+from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi, UserType
 from bitwarden_manager.onboard_user import OnboardUser
 from bitwarden_manager.clients.user_management_api import UserManagementApi
 from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
@@ -25,7 +25,53 @@ def test_onboard_user_invites_user_to_org() -> None:
         bitwarden_vault_client=mock_client_bitwarden_vault,
     ).run(event)
 
-    mock_client_bitwarden.invite_user.assert_called_with(username="test.user", email="testemail@example.com")
+    mock_client_bitwarden.invite_user.assert_called_with(
+        username="test.user", email="testemail@example.com", type=UserType.REGULAR_USER
+    )
+
+
+def test_onboard_non_admin_user_invites_user_to_org() -> None:
+    event = {
+        "event_name": "new_user",
+        "username": "test.user",
+        "email": "testemail@example.com",
+        "team_admin": False,
+    }
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
+    mock_client_user_management = MagicMock(spec=UserManagementApi)
+    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
+
+    OnboardUser(
+        bitwarden_api=mock_client_bitwarden,
+        user_management_api=mock_client_user_management,
+        bitwarden_vault_client=mock_client_bitwarden_vault,
+    ).run(event)
+
+    mock_client_bitwarden.invite_user.assert_called_with(
+        username="test.user", email="testemail@example.com", type=UserType.REGULAR_USER
+    )
+
+
+def test_onboard_admin_user_invites_user_to_org() -> None:
+    event = {
+        "event_name": "new_user",
+        "username": "test.user",
+        "email": "testemail@example.com",
+        "team_admin": True,
+    }
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
+    mock_client_user_management = MagicMock(spec=UserManagementApi)
+    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
+
+    OnboardUser(
+        bitwarden_api=mock_client_bitwarden,
+        user_management_api=mock_client_user_management,
+        bitwarden_vault_client=mock_client_bitwarden_vault,
+    ).run(event)
+
+    mock_client_bitwarden.invite_user.assert_called_with(
+        username="test.user", email="testemail@example.com", type=UserType.MANAGER
+    )
 
 
 def test_onboard_user_rejects_bad_events() -> None:


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/PSEC-2027

- All users are still invited as Regular Users unless the new "Team Admin" flag is passed
- If the flag is omitted or passed as false users are invited as Regular Users, if it's passed as true they're invited as Managers

