### PR TITLE
PSEC-2026: Reinvite pending users to Bitwarden

### DIFF
--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -16,6 +16,14 @@ class UserType(IntEnum):
     CUSTOM = 4
 
 
+# https://github.com/bitwarden/server/blob/main/src/Core/AdminConsole/Enums/OrganizationUserStatusType.cs
+class UserStatus(IntEnum):
+    INVITED = 0
+    ACCEPTED = 1
+    CONFIRMED = 2
+    REVOKED = -1
+
+
 REQUEST_TIMEOUT_SECONDS = 30
 
 LOGIN_URL = "https://identity.bitwarden.com/connect/token"
@@ -68,13 +76,7 @@ class BitwardenPublicApi:
         return not bool(external_id and external_id.strip())
 
     def __fetch_user_id(self, email: Optional[str] = None, external_id: Optional[str] = None) -> str:
-        response = session.get(f"{API_URL}/members")
-        try:
-            response.raise_for_status()
-        except HTTPError as error:
-            raise Exception("Failed to retrieve users", response.content, error) from error
-        response_json: Dict[str, Any] = response.json()
-        for user in response_json.get("data", ""):
+        for user in self.get_users():
             if external_id and external_id == user.get("externalId", ""):
                 return str(user.get("id", ""))
             if email and email == user.get("email", ""):
@@ -132,6 +134,23 @@ class BitwardenPublicApi:
             return response_json.get("data", [])
         except HTTPError as error:
             raise Exception("Failed to list collections", response.content, error) from error
+
+    def get_users(self) -> List[Dict[str, Any]]:
+        response = session.get(f"{API_URL}/members", timeout=REQUEST_TIMEOUT_SECONDS)
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to retrieve users", response.content, error) from error
+        response_json: Dict[str, Any] = response.json()
+        return response_json.get("data", [])
+
+    def get_pending_users(self) -> List[Dict[str, Any]]:
+        self.__fetch_token()
+        pending = []
+        for user in self.get_users():
+            if user.get("status") == UserStatus.INVITED:
+                pending.append(user)
+        return pending
 
     def invite_user(self, username: str, email: str, type: UserType = UserType.REGULAR_USER) -> str:
         self.__fetch_token()

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -181,6 +181,14 @@ class BitwardenPublicApi:
         response_json: Dict[str, str] = response.json()
         return response_json.get("id", "")
 
+    def reinvite_user(self, id: str, username: str) -> None:
+        response = session.post(f"{API_URL}/members/{id}/reinvite", timeout=REQUEST_TIMEOUT_SECONDS)
+        try:
+            response.raise_for_status()
+            self.__logger.info(f"{username} has been reinvited to Bitwarden")
+        except HTTPError as error:
+            raise Exception(f"Failed to reinvite {username}", response.content, error) from error
+
     def remove_user(self, username: str) -> None:
         self.__fetch_token()
         id = self.__fetch_user_id_by_external_id(external_id=username)

--- a/bitwarden_manager/clients/dynamodb_client.py
+++ b/bitwarden_manager/clients/dynamodb_client.py
@@ -28,3 +28,15 @@ class DynamodbClient:
             return table.get_item(Key=key)["Item"]
         except (BotoCoreError, ClientError) as e:
             raise Exception("Failed to read from DynamoDB", e) from e
+
+    def update_item_in_table(self, table_name: str, key: Dict[str, Any], reinvites: int) -> None:
+        try:
+            table = self._boto_dynamodb.Table(table_name)
+            table.update_item(
+                Key=key,
+                UpdateExpression="set reinvites=:r",
+                ExpressionAttributeValues={":r": reinvites},
+                ReturnValues="UPDATED_NEW",
+            )
+        except (BotoCoreError, ClientError) as e:
+            raise Exception("Failed to update item in DynamoDB", e) from e

--- a/bitwarden_manager/clients/dynamodb_client.py
+++ b/bitwarden_manager/clients/dynamodb_client.py
@@ -21,3 +21,10 @@ class DynamodbClient:
             table.delete_item(Key=key)
         except (BotoCoreError, ClientError) as e:
             raise Exception("Failed to delete from DynamoDB", e) from e
+
+    def get_item_from_table(self, table_name: str, key: Dict[str, Any]) -> Any:
+        try:
+            table = self._boto_dynamodb.Table(table_name)
+            return table.get_item(Key=key)["Item"]
+        except (BotoCoreError, ClientError) as e:
+            raise Exception("Failed to read from DynamoDB", e) from e

--- a/bitwarden_manager/onboard_user.py
+++ b/bitwarden_manager/onboard_user.py
@@ -66,7 +66,7 @@ class OnboardUser:
         )
         date = datetime.today().strftime("%Y-%m-%d")
         self.dynamodb_client.write_item_to_table(
-            table_name="bitwarden", item={"username": event["username"], "invite_date": date}
+            table_name="bitwarden", item={"username": event["username"], "invite_date": date, "reinvites": 0}
         )
         existing_groups = self.bitwarden_api.list_existing_groups(teams)
         existing_collections = self.bitwarden_api.list_existing_collections(teams)

--- a/bitwarden_manager/reinvite_users.py
+++ b/bitwarden_manager/reinvite_users.py
@@ -31,7 +31,10 @@ class ReinviteUsers:
         date = datetime.today() - timedelta(days=5)
         for user in self.bitwarden_api.get_pending_users():
             username = user.get("externalId", "")
-            record = self.dynamodb_client.get_item_from_table(table_name="bitwarden", key={"username": username})
+            key = {"username": username}
+            record = self.dynamodb_client.get_item_from_table(table_name="bitwarden", key=key)
             invite_date = datetime.strptime(record.get("invite_date", ""), "%Y-%m-%d")
             if invite_date < date:
                 self.bitwarden_api.reinvite_user(id=user.get("id", ""), username=username)
+                reinvites = record.get("reinvites", 0) + 1
+                self.dynamodb_client.update_item_in_table(table_name="bitwarden", key=key, reinvites=reinvites)

--- a/bitwarden_manager/reinvite_users.py
+++ b/bitwarden_manager/reinvite_users.py
@@ -15,6 +15,8 @@ reinvite_users_event_schema = {
     "required": ["event_name"],
 }
 
+MAX_REINVITES = 1
+
 
 class ReinviteUsers:
     def __init__(
@@ -34,7 +36,8 @@ class ReinviteUsers:
             key = {"username": username}
             record = self.dynamodb_client.get_item_from_table(table_name="bitwarden", key=key)
             invite_date = datetime.strptime(record.get("invite_date", ""), "%Y-%m-%d")
-            if invite_date < date:
+            reinvites = record.get("reinvites", 0)
+            if invite_date < date and reinvites < MAX_REINVITES:
                 self.bitwarden_api.reinvite_user(id=user.get("id", ""), username=username)
-                reinvites = record.get("reinvites", 0) + 1
+                reinvites += 1
                 self.dynamodb_client.update_item_in_table(table_name="bitwarden", key=key, reinvites=reinvites)

--- a/bitwarden_manager/reinvite_users.py
+++ b/bitwarden_manager/reinvite_users.py
@@ -1,0 +1,29 @@
+from typing import Dict, Any
+from jsonschema import validate
+
+from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
+from bitwarden_manager.clients.dynamodb_client import DynamodbClient
+
+
+reinvite_users_event_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "event_name": {"type": "string", "description": "name of the current event", "pattern": "reinvite_users"},
+    },
+    "required": ["event_name"],
+}
+
+
+class ReinviteUsers:
+    def __init__(
+        self,
+        bitwarden_api: BitwardenPublicApi,
+        dynamodb_client: DynamodbClient,
+    ):
+        self.bitwarden_api = bitwarden_api
+        self.dynamodb_client = dynamodb_client
+
+    def run(self, event: Dict[str, Any]) -> None:
+        validate(instance=event, schema=reinvite_users_event_schema)
+        self.bitwarden_api.get_pending_users()

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -1090,6 +1090,64 @@ def test_remove_user_with_failure(caplog: LogCaptureFixture) -> None:
             )
 
 
+def test_get_users(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/members",
+            body=open("tests/bitwarden_manager/resources/get_members.json").read(),
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        client.get_users()
+
+
+def test_get_users_failure(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/members",
+            body=b'{"object":"error","message":"The request\'s model state is invalid."}',
+            status=400,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        with pytest.raises(Exception, match="Failed to retrieve users"):
+            client.get_users()
+
+
+def test_get_pending_users(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.GET,
+            "https://api.bitwarden.com/public/members",
+            body=open("tests/bitwarden_manager/resources/get_members.json").read(),
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        assert client.get_pending_users()[0].get("name") == "test user03"
+
+
 # Helper functions
 
 

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -1148,6 +1148,43 @@ def test_get_pending_users(caplog: LogCaptureFixture) -> None:
         assert client.get_pending_users()[0].get("name") == "test user03"
 
 
+def test_reinvite_user(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/members/22222222/reinvite",
+            status=200,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        client.reinvite_user(id="22222222", username="test.user02")
+
+
+def test_reinvite_user_failed(caplog: LogCaptureFixture) -> None:
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
+        rsps.add(
+            responses.POST,
+            "https://api.bitwarden.com/public/members/22222222/reinvite",
+            status=500,
+            content_type="application/json",
+        )
+
+        client = BitwardenPublicApi(
+            logger=logging.getLogger(),
+            client_id="foo",
+            client_secret="bar",
+        )
+        with pytest.raises(Exception, match="Failed to reinvite test.user02"):
+            client.reinvite_user(id="22222222", username="test.user02")
+
+
 # Helper functions
 
 

--- a/tests/bitwarden_manager/clients/test_dynamodb_client.py
+++ b/tests/bitwarden_manager/clients/test_dynamodb_client.py
@@ -52,6 +52,22 @@ def test_delete_item_from_table() -> None:
     assert table.scan().get("Count") == 0
 
 
+@mock_dynamodb  # type: ignore
+def test_get_item_from_table() -> None:
+    client = DynamodbClient()
+
+    table_name = "bitwarden"
+    date = datetime.today().strftime("%Y-%m-%d")
+    item = {"username": "test.user", "date": date}
+
+    dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
+    create_table_in_local_region(dynamodb, table_name)
+    table = dynamodb.Table(table_name)
+    table.put_item(Item=item)
+    key = {"username": "test.user"}
+    assert client.get_item_from_table(table_name=table_name, key=key) == item
+
+
 def test_failed_to_write_item_to_table() -> None:
     client = DynamodbClient()
 
@@ -69,3 +85,12 @@ def test_failed_to_delete_item_from_table() -> None:
     key = {"username": "test.user"}
     with pytest.raises(Exception, match="Failed to delete from DynamoDB"):
         client.delete_item_from_table(table_name=table_name, key=key)
+
+
+def test_failed_to_get_item_from_table() -> None:
+    client = DynamodbClient()
+
+    table_name = "bitwarden"
+    key = {"username": "test.user"}
+    with pytest.raises(Exception, match="Failed to read from DynamoDB"):
+        client.get_item_from_table(table_name=table_name, key=key)

--- a/tests/bitwarden_manager/clients/test_dynamodb_client.py
+++ b/tests/bitwarden_manager/clients/test_dynamodb_client.py
@@ -22,7 +22,7 @@ def test_write_item_to_table() -> None:
 
     table_name = "bitwarden"
     date = datetime.today().strftime("%Y-%m-%d")
-    item = {"username": "test.user", "date": date}
+    item = {"username": "test.user", "date": date, "reinvites": 0}
 
     dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
     create_table_in_local_region(dynamodb, table_name)
@@ -40,7 +40,7 @@ def test_delete_item_from_table() -> None:
 
     table_name = "bitwarden"
     date = datetime.today().strftime("%Y-%m-%d")
-    item = {"username": "test.user", "date": date}
+    item = {"username": "test.user", "date": date, "reinvites": 0}
 
     dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
     create_table_in_local_region(dynamodb, table_name)
@@ -58,7 +58,7 @@ def test_get_item_from_table() -> None:
 
     table_name = "bitwarden"
     date = datetime.today().strftime("%Y-%m-%d")
-    item = {"username": "test.user", "date": date}
+    item = {"username": "test.user", "date": date, "reinvites": 0}
 
     dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
     create_table_in_local_region(dynamodb, table_name)
@@ -68,12 +68,30 @@ def test_get_item_from_table() -> None:
     assert client.get_item_from_table(table_name=table_name, key=key) == item
 
 
+@mock_dynamodb  # type: ignore
+def test_update_item_in_table() -> None:
+    client = DynamodbClient()
+
+    table_name = "bitwarden"
+    date = datetime.today().strftime("%Y-%m-%d")
+    item = {"username": "test.user", "date": date, "reinvites": 0}
+    updated_item = {"username": "test.user", "date": date, "reinvites": 1}
+
+    dynamodb = boto3.resource("dynamodb", region_name="eu-west-2")
+    create_table_in_local_region(dynamodb, table_name)
+    table = dynamodb.Table(table_name)
+    table.put_item(Item=item)
+    key = {"username": "test.user"}
+    client.update_item_in_table(table_name=table_name, key=key, reinvites=1)
+    assert client.get_item_from_table(table_name=table_name, key=key) == updated_item
+
+
 def test_failed_to_write_item_to_table() -> None:
     client = DynamodbClient()
 
     table_name = "bitwarden"
     date = datetime.today().strftime("%Y-%m-%d")
-    item = {"username": "test.user", "date": date}
+    item = {"username": "test.user", "date": date, "reinvites": 0}
     with pytest.raises(Exception, match="Failed to write to DynamoDB"):
         client.write_item_to_table(table_name=table_name, item=item)
 
@@ -94,3 +112,12 @@ def test_failed_to_get_item_from_table() -> None:
     key = {"username": "test.user"}
     with pytest.raises(Exception, match="Failed to read from DynamoDB"):
         client.get_item_from_table(table_name=table_name, key=key)
+
+
+def test_failed_to_update_item_in_table() -> None:
+    client = DynamodbClient()
+
+    table_name = "bitwarden"
+    key = {"username": "test.user"}
+    with pytest.raises(Exception, match="Failed to update item in DynamoDB"):
+        client.update_item_in_table(table_name=table_name, key=key, reinvites=1)

--- a/tests/bitwarden_manager/resources/get_members.json
+++ b/tests/bitwarden_manager/resources/get_members.json
@@ -36,7 +36,7 @@
         "name": "test user03",
         "email": "test.user03@example.com",
         "twoFactorEnabled": true,
-        "status": 2,
+        "status": 0,
         "collections": null,
         "type": 1,
         "accessAll": false,

--- a/tests/bitwarden_manager/test_onboard_user.py
+++ b/tests/bitwarden_manager/test_onboard_user.py
@@ -193,5 +193,5 @@ def test_onboard_user_writes_invite_date_to_db() -> None:
 
     date = datetime.today().strftime("%Y-%m-%d")
     mock_client_dynamodb.write_item_to_table.assert_called_with(
-        table_name="bitwarden", item={"username": "test.user", "invite_date": date}
+        table_name="bitwarden", item={"username": "test.user", "invite_date": date, "reinvites": 0}
     )

--- a/tests/bitwarden_manager/test_reinvite_users.py
+++ b/tests/bitwarden_manager/test_reinvite_users.py
@@ -13,12 +13,37 @@ def test_reinvite_users() -> None:
     mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
     mock_client_dynamodb = MagicMock(spec=DynamodbClient)
 
+    mock_client_bitwarden.get_pending_users = MagicMock(
+        return_value=[
+            {
+                "object": "member",
+                "id": "22222222",
+                "userId": "",
+                "name": "test user02",
+                "email": "test.user02@example.com",
+                "twoFactorEnabled": True,
+                "status": 0,
+                "collections": [],
+                "type": 1,
+                "accessAll": False,
+                "externalId": "test.user02",
+                "resetPasswordEnrolled": False,
+            },
+        ]
+    )
+
+    mock_client_dynamodb.get_item_from_table = MagicMock(
+        return_value={"username": "test.user02", "invite_date": "2024-01-01"}
+    )
+
     ReinviteUsers(
         bitwarden_api=mock_client_bitwarden,
         dynamodb_client=mock_client_dynamodb,
     ).run(event)
 
     mock_client_bitwarden.get_pending_users.assert_called
+    mock_client_dynamodb.get_item_from_table.assert_called_with(table_name="bitwarden", key={"username": "test.user02"})
+    mock_client_bitwarden.reinvite_user.assert_called_with(id="22222222", username="test.user02")
 
 
 def test_reinvite_users_rejects_bad_events() -> None:

--- a/tests/bitwarden_manager/test_reinvite_users.py
+++ b/tests/bitwarden_manager/test_reinvite_users.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
+from bitwarden_manager.clients.dynamodb_client import DynamodbClient
+from bitwarden_manager.reinvite_users import ReinviteUsers
+
+
+def test_reinvite_users() -> None:
+    event = {"event_name": "reinvite_users"}
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
+    mock_client_dynamodb = MagicMock(spec=DynamodbClient)
+
+    ReinviteUsers(
+        bitwarden_api=mock_client_bitwarden,
+        dynamodb_client=mock_client_dynamodb,
+    ).run(event)
+
+    mock_client_bitwarden.get_pending_users.assert_called
+
+
+def test_reinvite_users_rejects_bad_events() -> None:
+    event = {"somthing?": 1}
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
+    mock_client_dynamodb = MagicMock(spec=DynamodbClient)
+
+    with pytest.raises(ValidationError, match="'event_name' is a required property"):
+        ReinviteUsers(
+            bitwarden_api=mock_client_bitwarden,
+            dynamodb_client=mock_client_dynamodb,
+        ).run(event)
+
+        assert not mock_client_bitwarden.get_pending_users.assert_called

--- a/tests/bitwarden_manager/test_reinvite_users.py
+++ b/tests/bitwarden_manager/test_reinvite_users.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 from jsonschema.exceptions import ValidationError
@@ -29,29 +29,12 @@ def test_reinvite_users() -> None:
                 "accessAll": False,
                 "externalId": "test.user02",
                 "resetPasswordEnrolled": False,
-            },
-            {
-                "object": "member",
-                "id": "333333",
-                "userId": "",
-                "name": "test user03",
-                "email": "test.user03@example.com",
-                "twoFactorEnabled": True,
-                "status": 0,
-                "collections": [],
-                "type": 1,
-                "accessAll": False,
-                "externalId": "test.user03",
-                "resetPasswordEnrolled": False,
-            },
+            }
         ]
     )
 
     mock_client_dynamodb.get_item_from_table = MagicMock(
-        side_effect=[
-            {"username": "test.user02", "invite_date": "2024-01-01"},
-            {"username": "test.user03", "invite_date": datetime.today().strftime("%Y-%m-%d")},
-        ]
+        return_value={"username": "test.user02", "invite_date": "2024-01-01", "reinvites": 0}
     )
 
     ReinviteUsers(
@@ -60,12 +43,84 @@ def test_reinvite_users() -> None:
     ).run(event)
 
     mock_client_bitwarden.get_pending_users.assert_called
-    dynamodb_calls = [
-        call(table_name="bitwarden", key={"username": "test.user02"}),
-        call(table_name="bitwarden", key={"username": "test.user03"}),
-    ]
-    mock_client_dynamodb.get_item_from_table.assert_has_calls(dynamodb_calls)
+    mock_client_dynamodb.get_item_from_table.assert_called_with(table_name="bitwarden", key={"username": "test.user02"})
     mock_client_bitwarden.reinvite_user.assert_called_with(id="22222222", username="test.user02")
+
+
+def test_reinvite_pending_users_invite_not_expired_yet() -> None:
+    event = {"event_name": "reinvite_users"}
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
+    mock_client_dynamodb = MagicMock(spec=DynamodbClient)
+
+    mock_client_bitwarden.get_pending_users = MagicMock(
+        return_value=[
+            {
+                "object": "member",
+                "id": "22222222",
+                "userId": "",
+                "name": "test user02",
+                "email": "test.user02@example.com",
+                "twoFactorEnabled": True,
+                "status": 0,
+                "collections": [],
+                "type": 1,
+                "accessAll": False,
+                "externalId": "test.user02",
+                "resetPasswordEnrolled": False,
+            }
+        ]
+    )
+
+    mock_client_dynamodb.get_item_from_table = MagicMock(
+        return_value={"username": "test.user02", "invite_date": datetime.today().strftime("%Y-%m-%d"), "reinvites": 0}
+    )
+
+    ReinviteUsers(
+        bitwarden_api=mock_client_bitwarden,
+        dynamodb_client=mock_client_dynamodb,
+    ).run(event)
+
+    mock_client_bitwarden.get_pending_users.assert_called
+    mock_client_dynamodb.get_item_from_table.assert_called_with(table_name="bitwarden", key={"username": "test.user02"})
+    assert not mock_client_bitwarden.reinvite_user.called
+
+
+def test_reinvite_pending_users_already_reinvited() -> None:
+    event = {"event_name": "reinvite_users"}
+    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
+    mock_client_dynamodb = MagicMock(spec=DynamodbClient)
+
+    mock_client_bitwarden.get_pending_users = MagicMock(
+        return_value=[
+            {
+                "object": "member",
+                "id": "22222222",
+                "userId": "",
+                "name": "test user02",
+                "email": "test.user02@example.com",
+                "twoFactorEnabled": True,
+                "status": 0,
+                "collections": [],
+                "type": 1,
+                "accessAll": False,
+                "externalId": "test.user02",
+                "resetPasswordEnrolled": False,
+            }
+        ]
+    )
+
+    mock_client_dynamodb.get_item_from_table = MagicMock(
+        return_value={"username": "test.user02", "invite_date": "2024-01-01", "reinvites": 1}
+    )
+
+    ReinviteUsers(
+        bitwarden_api=mock_client_bitwarden,
+        dynamodb_client=mock_client_dynamodb,
+    ).run(event)
+
+    mock_client_bitwarden.get_pending_users.assert_called
+    mock_client_dynamodb.get_item_from_table.assert_called_with(table_name="bitwarden", key={"username": "test.user02"})
+    assert not mock_client_bitwarden.reinvite_user.called
 
 
 def test_reinvite_users_rejects_bad_events() -> None:


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/PSEC-2026

For users that have been invited to Bitwarden, but not accepted the invite within 5 days - the invite will expire. We should automatically re-invite those users once. Since Bitwarden itself doesn't expose when a user was invited or how many times they've been re-invited, we track this in a DynamoDB table. The table is billed per use rather than provisioned as we expect usage to be relatively low (1 write for each onboard/offboard event, and 1 read per day per pending user).

- [x] Get pending users from Bitwarden
- [x] Check their invite date and reinvite count against DynamoDB table
- [x] Send re-invite
- [x] Update table
- [ ] Schedule task (platsec-terraform)