### PR TITLE
PSEC-2031-handle-login-errors-gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHELL = /bin/bash
 .PHONY: $(MAKECMDGOALS)
 
 PYTHON_VERSION = $(shell head -1 .python-version)
+PYTHON_SRC = *.py bitwarden_manager/ tests/
 
 POETRY_DOCKER = docker run \
 	--interactive \
@@ -37,16 +38,16 @@ flake8: python
 	@$(POETRY_DOCKER) flake8 --max-line-length 120 --exclude=.venv
 
 fmt:
-	@$(POETRY_DOCKER_MOUNT) black --line-length 120 --exclude=.venv .
+	@$(POETRY_DOCKER_MOUNT) black --line-length 120 --exclude=.venv $(PYTHON_SRC)
 
 fmt-check: python
-	@$(POETRY_DOCKER) black --line-length 120 --check .
+	@$(POETRY_DOCKER) black --line-length 120 --check $(PYTHON_SRC)
 
 mypy: python
-	@$(POETRY_DOCKER) mypy --strict .
+	@$(POETRY_DOCKER) mypy --strict $(PYTHON_SRC)
 
 bandit: python
-	@$(POETRY_DOCKER) bandit -c bandit.yaml -r -q .
+	@$(POETRY_DOCKER) bandit -c bandit.yaml -r -q $(PYTHON_SRC)
 
 python-test: python
 	@$(POETRY_DOCKER) pytest \

--- a/bitwarden_manager/bitwarden_manager.py
+++ b/bitwarden_manager/bitwarden_manager.py
@@ -6,7 +6,7 @@ import boto3
 
 from bitwarden_manager.clients.aws_secretsmanager_client import AwsSecretsManagerClient
 from bitwarden_manager.clients.bitwarden_public_api import BitwardenPublicApi
-from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient, BitwardenVaultClientLoginError
 from bitwarden_manager.clients.s3_client import S3Client
 from bitwarden_manager.clients.dynamodb_client import DynamodbClient
 from bitwarden_manager.clients.user_management_api import UserManagementApi
@@ -79,6 +79,8 @@ class BitwardenManager:
                     ).run(event=event)
                 case _:
                     self.__logger.info(f"ignoring unknown event '{event_name}'")
+        except BitwardenVaultClientLoginError as e:
+            self.__logger.warning(f"Failed to complete {event_name} due to Bitwarden CLI login error - {e}")
         finally:
             bitwarden_vault_client.logout()
 

--- a/bitwarden_manager/clients/bitwarden_vault_client.py
+++ b/bitwarden_manager/clients/bitwarden_vault_client.py
@@ -12,6 +12,10 @@ class BitwardenVaultClientError(Exception):
     pass
 
 
+class BitwardenVaultClientLoginError(Exception):
+    pass
+
+
 class BitwardenVaultClient:
     __session_token: Optional[str]
 
@@ -49,7 +53,7 @@ class BitwardenVaultClient:
                 text=True,
             )  # nosec B603
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            raise BitwardenVaultClientError(e)
+            raise BitwardenVaultClientLoginError(e)
         return output
 
     def _unlock(self) -> str:

--- a/tests/bitwarden_manager/clients/stubs/bitwarden_client_failing_authentication_stub.py
+++ b/tests/bitwarden_manager/clients/stubs/bitwarden_client_failing_authentication_stub.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     match sys.argv[1]:
         case "login":
             sys.stdout.write("")
-            sys.stderr.write("Username or password is incorrect. Try again.")
+            sys.stderr.write("Something went wrong. Try again.")
             sys.exit(1)
         case "unlock":
             sys.stdout.write("")

--- a/tests/bitwarden_manager/clients/stubs/bitwarden_client_incorrect_credentials_stub.py
+++ b/tests/bitwarden_manager/clients/stubs/bitwarden_client_incorrect_credentials_stub.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import sys
+
+if __name__ == "__main__":
+    match sys.argv[1]:
+        case "login":
+            sys.stdout.write("client_id or client_secret is incorrect. Try again.")
+            sys.stderr.write("")
+            sys.exit(1)
+        case "unlock":
+            sys.stdout.write("")
+            sys.stderr.write("You are not logged in.")
+            sys.exit(1)
+        case "logout":
+            sys.stdout.write("")
+            sys.stderr.write("You are not logged in.")
+            sys.exit(1)
+        case _:
+            sys.stderr.write("This is a fake error")
+            sys.exit(1)

--- a/tests/bitwarden_manager/clients/stubs/bitwarden_client_incorrect_credentials_stub.py
+++ b/tests/bitwarden_manager/clients/stubs/bitwarden_client_incorrect_credentials_stub.py
@@ -4,8 +4,8 @@ import sys
 if __name__ == "__main__":
     match sys.argv[1]:
         case "login":
-            sys.stdout.write("client_id or client_secret is incorrect. Try again.")
-            sys.stderr.write("")
+            sys.stdout.write("")
+            sys.stderr.write("client_id or client_secret is incorrect. Try again.")
             sys.exit(1)
         case "unlock":
             sys.stdout.write("")

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import logging
 import tempfile
 from unittest import mock
@@ -11,72 +10,12 @@ from _pytest.logging import LogCaptureFixture
 from bitwarden_manager.clients.bitwarden_vault_client import (
     BitwardenVaultClient,
     BitwardenVaultClientError,
+    BitwardenVaultClientLoginError,
 )
 
 
-@pytest.fixture
-def client() -> BitwardenVaultClient:
-    return BitwardenVaultClient(
-        cli_executable_path=str(pathlib.Path(__file__).parent.joinpath("./stubs/bitwarden_client_stub.py")),
-        client_id="test_id",
-        client_secret="test_secret",
-        export_enc_password="hmrc2023",
-        logger=logging.getLogger(),
-        organisation_id="abc-123",
-        password="very secure pa$$w0rd!",
-        cli_timeout=20,
-    )
-
-
-@pytest.fixture
-@mock.patch.dict(os.environ, {"BITWARDEN_CLI_TIMEOUT": "1"})
-def timeout_client() -> BitwardenVaultClient:
-    return BitwardenVaultClient(
-        cli_executable_path=str(pathlib.Path(__file__).parent.joinpath("./stubs/bitwarden_client_stub.py")),
-        client_id="test_id",
-        client_secret="test_secret",
-        export_enc_password="hmrc2023",
-        logger=logging.getLogger(),
-        organisation_id="abc-123",
-        password="very secure pa$$w0rd!",
-        cli_timeout=float(os.environ.get("BITWARDEN_CLI_TIMEOUT", "20")),
-    )
-
-
-@pytest.fixture
-def failing_client() -> BitwardenVaultClient:
-    return BitwardenVaultClient(
-        cli_executable_path=str(
-            pathlib.Path(__file__).parent.joinpath("./stubs/bitwarden_client_failing_operations_stub.py")
-        ),
-        client_id="test_id",
-        client_secret="test_secret",
-        export_enc_password="hmrc2023",
-        logger=logging.getLogger(),
-        organisation_id="abc-123",
-        password="very secure pa$$w0rd!",
-        cli_timeout=20,
-    )
-
-
-@pytest.fixture
-def failing_authentication_client() -> BitwardenVaultClient:
-    return BitwardenVaultClient(
-        cli_executable_path=str(
-            pathlib.Path(__file__).parent.joinpath("./stubs/bitwarden_client_failing_authentication_stub.py")
-        ),
-        client_id="test_id",
-        client_secret="test_secret",
-        export_enc_password="hmrc2023",
-        logger=logging.getLogger(),
-        organisation_id="abc-123",
-        password="very secure pa$$w0rd!",
-        cli_timeout=20,
-    )
-
-
 def test_failed_login(failing_authentication_client: BitwardenVaultClient) -> None:
-    with pytest.raises(BitwardenVaultClientError, match="login"):
+    with pytest.raises(BitwardenVaultClientLoginError, match="login"):
         failing_authentication_client.login()
 
 
@@ -86,7 +25,7 @@ def test_only_logout_if_logged_in(failing_authentication_client: BitwardenVaultC
 
 @mock.patch.dict(os.environ, {"BITWARDEN_CLI_TIMEOUT": "1"})
 def test_login_timed_out(timeout_client: BitwardenVaultClient) -> None:
-    with pytest.raises(BitwardenVaultClientError, match="timed out after 1.0 seconds"):
+    with pytest.raises(BitwardenVaultClientLoginError, match="timed out after 1.0 seconds"):
         timeout_client.login()
 
 

--- a/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_vault_client.py
@@ -10,13 +10,14 @@ from _pytest.logging import LogCaptureFixture
 from bitwarden_manager.clients.bitwarden_vault_client import (
     BitwardenVaultClient,
     BitwardenVaultClientError,
+    BitwardenVaultClientIncorrectCredentialsError,
     BitwardenVaultClientLoginError,
 )
 
 
-def test_failed_login(failing_authentication_client: BitwardenVaultClient) -> None:
-    with pytest.raises(BitwardenVaultClientLoginError, match="login"):
-        failing_authentication_client.login()
+def test_failed_login(incorrect_credentials_client: BitwardenVaultClient) -> None:
+    with pytest.raises(BitwardenVaultClientIncorrectCredentialsError, match="login"):
+        incorrect_credentials_client.login()
 
 
 def test_only_logout_if_logged_in(failing_authentication_client: BitwardenVaultClient) -> None:

--- a/tests/bitwarden_manager/conftest.py
+++ b/tests/bitwarden_manager/conftest.py
@@ -66,3 +66,19 @@ def failing_authentication_client() -> BitwardenVaultClient:
         password="very secure pa$$w0rd!",
         cli_timeout=20,
     )
+
+
+@pytest.fixture
+def incorrect_credentials_client() -> BitwardenVaultClient:
+    return BitwardenVaultClient(
+        cli_executable_path=str(
+            pathlib.Path(__file__).parent.joinpath("./clients/stubs/bitwarden_client_incorrect_credentials_stub.py")
+        ),
+        client_id="test_id",
+        client_secret="test_secret",
+        export_enc_password="hmrc2023",
+        logger=logging.getLogger(),
+        organisation_id="abc-123",
+        password="very secure pa$$w0rd!",
+        cli_timeout=20,
+    )

--- a/tests/bitwarden_manager/conftest.py
+++ b/tests/bitwarden_manager/conftest.py
@@ -1,0 +1,68 @@
+import logging
+import os
+import pathlib
+from unittest import mock
+import pytest
+
+from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClient
+
+
+@pytest.fixture
+def client() -> BitwardenVaultClient:
+    return BitwardenVaultClient(
+        cli_executable_path=str(pathlib.Path(__file__).parent.joinpath("./clients/stubs/bitwarden_client_stub.py")),
+        client_id="test_id",
+        client_secret="test_secret",
+        export_enc_password="hmrc2023",
+        logger=logging.getLogger(),
+        organisation_id="abc-123",
+        password="very secure pa$$w0rd!",
+        cli_timeout=20,
+    )
+
+
+@pytest.fixture
+@mock.patch.dict(os.environ, {"BITWARDEN_CLI_TIMEOUT": "1"})
+def timeout_client() -> BitwardenVaultClient:
+    return BitwardenVaultClient(
+        cli_executable_path=str(pathlib.Path(__file__).parent.joinpath("./clients/stubs/bitwarden_client_stub.py")),
+        client_id="test_id",
+        client_secret="test_secret",
+        export_enc_password="hmrc2023",
+        logger=logging.getLogger(),
+        organisation_id="abc-123",
+        password="very secure pa$$w0rd!",
+        cli_timeout=float(os.environ.get("BITWARDEN_CLI_TIMEOUT", "20")),
+    )
+
+
+@pytest.fixture
+def failing_client() -> BitwardenVaultClient:
+    return BitwardenVaultClient(
+        cli_executable_path=str(
+            pathlib.Path(__file__).parent.joinpath("./clients/stubs/bitwarden_client_failing_operations_stub.py")
+        ),
+        client_id="test_id",
+        client_secret="test_secret",
+        export_enc_password="hmrc2023",
+        logger=logging.getLogger(),
+        organisation_id="abc-123",
+        password="very secure pa$$w0rd!",
+        cli_timeout=20,
+    )
+
+
+@pytest.fixture
+def failing_authentication_client() -> BitwardenVaultClient:
+    return BitwardenVaultClient(
+        cli_executable_path=str(
+            pathlib.Path(__file__).parent.joinpath("./clients/stubs/bitwarden_client_failing_authentication_stub.py")
+        ),
+        client_id="test_id",
+        client_secret="test_secret",
+        export_enc_password="hmrc2023",
+        logger=logging.getLogger(),
+        organisation_id="abc-123",
+        password="very secure pa$$w0rd!",
+        cli_timeout=20,
+    )

--- a/tests/bitwarden_manager/test_bitwarden_manager.py
+++ b/tests/bitwarden_manager/test_bitwarden_manager.py
@@ -92,7 +92,7 @@ def test_confirm_user_passed_allowed_domains(mock_secretsmanager: Mock) -> None:
 
 @mock.patch.dict(os.environ, {"ALLOWED_DOMAINS": "example.com"})
 @mock.patch("boto3.client")
-def test_warning_log_on_failed_bitwarden_vault_client_login(
+def test_warning_is_logged_on_failed_bitwarden_vault_client_login(
     mock_secretsmanager: Mock, failing_authentication_client: BitwardenVaultClient, caplog: LogCaptureFixture
 ) -> None:
     get_secret_value = Mock(return_value={"SecretString": "secret"})

--- a/tests/bitwarden_manager/test_bitwarden_manager.py
+++ b/tests/bitwarden_manager/test_bitwarden_manager.py
@@ -1,6 +1,9 @@
+import logging
 import os
 from unittest import mock
 from unittest.mock import Mock, call, patch
+
+from pytest import LogCaptureFixture
 
 
 from bitwarden_manager.bitwarden_manager import BitwardenManager
@@ -85,6 +88,23 @@ def test_confirm_user_passed_allowed_domains(mock_secretsmanager: Mock) -> None:
         manager.run(event={"event_name": "confirm_user"})
 
     bitwarden_mock.confirm_user.assert_called_once_with(user_id=111)
+
+
+@mock.patch.dict(os.environ, {"ALLOWED_DOMAINS": "example.com"})
+@mock.patch("boto3.client")
+def test_warning_log_on_failed_bitwarden_vault_client_login(
+    mock_secretsmanager: Mock, failing_authentication_client: BitwardenVaultClient, caplog: LogCaptureFixture
+) -> None:
+    get_secret_value = Mock(return_value={"SecretString": "secret"})
+    mock_secretsmanager.return_value = Mock(get_secret_value=get_secret_value)
+
+    with patch.object(BitwardenManager, "_get_bitwarden_vault_client") as _get_bitwarden_vault_client:
+        _get_bitwarden_vault_client.return_value = failing_authentication_client
+
+        with caplog.at_level(logging.WARN):
+            BitwardenManager().run(event={"event_name": "confirm_user"})
+
+        assert "Failed to complete confirm_user due to Bitwarden CLI login error - " in caplog.text
 
 
 @mock.patch("boto3.client")


### PR DESCRIPTION
Gracefully handle failure due to bitwarden cli login failure

New exception, BitwardenVaultClientLoginError, created specificly for bitwarden cli login failure
to differentiate it from other cli failures that may occur, and that needs an engineers attention.
Login errors happen infrequently, have been found often to be out of our control, and self-resolves.
Hence, a warning level log has been added to give visibility when it happens.

> This means that we should not receive pagerduty alerts due to bitwarden cli login failure
