### PR TITLE
PSEC-2126-api-login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@ SHELL = /bin/bash
 
 .PHONY: $(MAKECMDGOALS)
 
+OS := $(shell uname -s | tr A-Z a-z)
+
+ifeq ($(OS), darwin)
+OS = macos
+endif
+
+BITWARDEN_CLI_VERSION := 2024.4.1
+
 PYTHON_VERSION = $(shell head -1 .python-version)
 PYTHON_SRC = *.py bitwarden_manager/ tests/
 
@@ -72,3 +80,10 @@ container-release:
 		--file Dockerfile \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 		--tag container-release:local .
+
+install-bitwarden-cli:
+	@curl -sL https://github.com/bitwarden/clients/releases/download/cli-v$(BITWARDEN_CLI_VERSION)/bw-macos-$(BITWARDEN_CLI_VERSION).zip -o bw.zip
+	@unzip -o bw.zip -d /usr/local/bin/ && rm -f bw.zip
+
+uninstall-bitwarden-cli:
+	@rm -f /usr/local/bin/bw

--- a/bitwarden_manager/temp/update_collection_external_ids.py
+++ b/bitwarden_manager/temp/update_collection_external_ids.py
@@ -106,7 +106,7 @@ class UpdateCollectionExternalIds:
         return [BitwardenCollection(name=c["name"], id=c["id"]) for c in data]
 
     def update_collection_external_id(self, collection_id: str, external_id: str) -> None:
-        put_response = session.put(
+        response = session.put(
             f"{API_URL}/collections/{collection_id}",
             json={
                 "externalId": external_id,
@@ -115,13 +115,14 @@ class UpdateCollectionExternalIds:
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
         try:
-            put_response.raise_for_status()
+            response.raise_for_status()
         except HTTPError as error:
             raise Exception("Failed to update the collection externalId") from error
 
     def reconcile_collection_external_ids(
         self, from_data_export_collections: List[BitwardenCollection], org_collections: List[BitwardenCollection]
     ) -> None:
+        self.bitwarden_api._BitwardenPublicApi__fetch_token()  # type: ignore
         for c in from_data_export_collections:
             for org_c in org_collections:
                 if c.name == org_c.name:

--- a/tests/bitwarden_manager/temp/test_update_collection_external_ids.py
+++ b/tests/bitwarden_manager/temp/test_update_collection_external_ids.py
@@ -12,6 +12,8 @@ from bitwarden_manager.clients.bitwarden_vault_client import BitwardenVaultClien
 from bitwarden_manager.temp.update_collection_external_ids import BitwardenCollection, UpdateCollectionExternalIds
 from responses import matchers
 
+from tests.bitwarden_manager.clients.test_bitwarden_public_api import MOCKED_LOGIN
+
 
 @pytest.fixture
 def client() -> BitwardenVaultClient:
@@ -131,6 +133,7 @@ def test_reconcile_collection_external_ids() -> None:
     ]
 
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(MOCKED_LOGIN)
         rsps.add(
             method=responses.PUT,
             url=f"https://api.bitwarden.eu/public/collections/id-{collection_01}",
@@ -156,7 +159,7 @@ def test_reconcile_collection_external_ids() -> None:
             from_data_export_collections=from_export_data_collections, org_collections=org_collections
         )
 
-        assert len(rsps.calls) == 2
+        assert len(rsps.calls) == 3
         assert rsps.calls[-1].request.method == "PUT"
 
 


### PR DESCRIPTION
Update collection external IDs from data export file re: Bitwarden EU migration

Included step to log in before attempting to update collection external id