### PR TITLE
PSEC-2126-data-export-schema

### DIFF
--- a/bitwarden_manager/temp/update_collection_external_ids.py
+++ b/bitwarden_manager/temp/update_collection_external_ids.py
@@ -41,7 +41,7 @@ data_export_schema = {
                     "id": {"type": "string"},
                     "organizationId": {"type": "string"},
                     "name": {"type": "string"},
-                    "externalId": {"type": ["string", None]},
+                    "externalId": {"type": ["string", "null"]},
                 },
             },
         },


### PR DESCRIPTION
Re: bitwarden migration - update schema check to allow null external ID