### PR TITLE
PSEC-2207-user-role

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ If the user already exists within BitWarden then the lambda will log this.
 {
     "event_name": "new_user",
     "username": "test.user01",
-    "email": "test.user01@example.com",
-    "role": "user"
+    "email": "test.user01@example.com"
 }
 ```
 

--- a/bitwarden_manager/clients/user_management_api.py
+++ b/bitwarden_manager/clients/user_management_api.py
@@ -1,5 +1,6 @@
 from logging import Logger
 from typing import Dict, Any, List
+from urllib.parse import quote
 from requests import get, post, HTTPError
 
 REQUEST_TIMEOUT_SECONDS = 5
@@ -42,6 +43,28 @@ class UserManagementApi:
                 user_teams.append(team.get("team", ""))
         self.__logger.info(f"User teams: {user_teams}")
         return user_teams
+
+    def get_user_role_by_team(self, username: str, team: str) -> str:
+        bearer = self.__fetch_token()
+        response = get(
+            f"{API_URL}/organisations/teams/{quote(team)}/members",
+            headers={
+                "Token": bearer,
+                "requester": self.__client_id,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            raise Exception(f"Failed to get team members of {team}", response.content, e) from e
+        response_json: Dict[str, Any] = response.json()
+        roles: List[str] = [m["role"] for m in response_json.get("members", []) if m["username"] == username]
+        if len(roles) == 0:
+            raise Exception(f"{username} is not a member of {team}")
+        return roles[0]
 
     def get_teams(self) -> List[str]:
         bearer = self.__fetch_token()

--- a/bitwarden_manager/user.py
+++ b/bitwarden_manager/user.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Optional
+from typing import Dict, Optional
 
 
 # Bitwarden server enum definition:
@@ -23,22 +23,20 @@ class UserStatus(IntEnum):
     REVOKED = -1
 
 
-ump_role_to_org_user_type_mapping = {
-    "user": {"org_user_type": UserType.REGULAR_USER, "can_manage_team_collection": False},
-    "super_admin": {"org_user_type": UserType.REGULAR_USER, "can_manage_team_collection": False},
-    "team_admin": {"org_user_type": UserType.REGULAR_USER, "can_manage_team_collection": True},
-    "all_team_admin": {"org_user_type": UserType.REGULAR_USER, "can_manage_team_collection": True},
+ump_role_to_collection_permission_mapping = {
+    "user": {"can_manage_team_collection": False},
+    "super_admin": {"can_manage_team_collection": False},
+    "team_admin": {"can_manage_team_collection": True},
+    "all_team_admin": {"can_manage_team_collection": True},
 }
 
 
 @dataclass
 class UmpUser:
     username: str
+    roles_by_team: Dict[str, str]
     email: Optional[str] = None
-    role: str = "user"
 
-    def org_user_type(self) -> int:
-        return ump_role_to_org_user_type_mapping[self.role]["org_user_type"]
-
-    def can_manage_team_collection(self) -> bool:
-        return bool(ump_role_to_org_user_type_mapping[self.role]["can_manage_team_collection"])
+    def can_manage_team_collection(self, team: str) -> bool:
+        role = self.roles_by_team.get(team, "user")
+        return bool(ump_role_to_collection_permission_mapping[role]["can_manage_team_collection"])

--- a/tests/bitwarden_manager/test_onboard_user.py
+++ b/tests/bitwarden_manager/test_onboard_user.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 from datetime import datetime
 
 import pytest
@@ -19,35 +19,14 @@ def test_onboard_user_invites_user_to_org() -> None:
         "email": "testemail@example.com",
     }
     mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
-    mock_client_user_management = MagicMock(spec=UserManagementApi)
     mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
     mock_client_dynamodb = MagicMock(spec=DynamodbClient)
-
-    OnboardUser(
-        bitwarden_api=mock_client_bitwarden,
-        user_management_api=mock_client_user_management,
-        bitwarden_vault_client=mock_client_bitwarden_vault,
-        dynamodb_client=mock_client_dynamodb,
-    ).run(event)
-
-    mock_client_bitwarden.invite_user.assert_called_with(
-        user=UmpUser(username="test.user", email="testemail@example.com", role="user")
+    mock_client_user_management = MagicMock(
+        spec=UserManagementApi,
+        get_user_teams=Mock(return_value=["team-one"]),
+        get_user_role_by_team=Mock(return_value="user"),
     )
 
-
-@pytest.mark.parametrize("role", [("user"), ("super_admin")])
-def test_onboard_non_admin_user_invites_user_to_org(role: str) -> None:
-    event = {
-        "event_name": "new_user",
-        "username": "test.user",
-        "email": "testemail@example.com",
-        "role": role,
-    }
-    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
-    mock_client_user_management = MagicMock(spec=UserManagementApi)
-    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
-    mock_client_dynamodb = MagicMock(spec=DynamodbClient)
-
     OnboardUser(
         bitwarden_api=mock_client_bitwarden,
         user_management_api=mock_client_user_management,
@@ -56,32 +35,7 @@ def test_onboard_non_admin_user_invites_user_to_org(role: str) -> None:
     ).run(event)
 
     mock_client_bitwarden.invite_user.assert_called_with(
-        user=UmpUser(username="test.user", email="testemail@example.com", role=role)
-    )
-
-
-@pytest.mark.parametrize("role", [("team_admin"), ("all_team_admin")])
-def test_onboard_team_admin_user_invites_user_to_org(role: str) -> None:
-    event = {
-        "event_name": "new_user",
-        "username": "test.user",
-        "email": "testemail@example.com",
-        "role": role,
-    }
-    mock_client_bitwarden = MagicMock(spec=BitwardenPublicApi)
-    mock_client_user_management = MagicMock(spec=UserManagementApi)
-    mock_client_bitwarden_vault = MagicMock(spec=BitwardenVaultClient)
-    mock_client_dynamodb = MagicMock(spec=DynamodbClient)
-
-    OnboardUser(
-        bitwarden_api=mock_client_bitwarden,
-        user_management_api=mock_client_user_management,
-        bitwarden_vault_client=mock_client_bitwarden_vault,
-        dynamodb_client=mock_client_dynamodb,
-    ).run(event)
-
-    mock_client_bitwarden.invite_user.assert_called_with(
-        user=UmpUser(username="test.user", email="testemail@example.com", role=role)
+        user=UmpUser(username="test.user", email="testemail@example.com", roles_by_team={"team-one": "user"})
     )
 
 


### PR DESCRIPTION
Fetch user role from UMP for 'can manage' collection permission

* removes 'role' field from 'new_user' event
* fixes existing tests