### PR TITLE
PSEC-2225 Fix user collection clobber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION
 
-FROM python:${PYTHON_VERSION}-slim AS base
+FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim AS base
 
 WORKDIR /build
 

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -212,7 +212,9 @@ class BitwardenPublicApi:
         bw_user_collections = self.__get_user_collections(bw_user.get("collections"))
         for bw_user_collection in bw_user_collections:
             if self.__collection_manually_created(bw_user_collection["id"]):
-                assign_collections.append(next(item for item in bw_user.get("collections") if item["id"] == bw_user_collection["id"]))
+                assign_collections.append(
+                    next(item for item in bw_user.get("collections") if item["id"] == bw_user_collection["id"])
+                )
 
         response = session.put(
             f"{API_URL}/members/{bw_user['id']}",

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -28,11 +28,11 @@ class BitwardenPublicApi:
     def external_id_base64_encoded(id: str) -> str:
         return base64.b64encode(id.encode()).decode("utf-8")
 
-    def __get_user_collections(self, user_collections: Optional[List[Dict]]) -> List[Dict]:
+    def __get_user_collections(self, user_collections: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
         if user_collections is None:
             return []
 
-        collections: List[Dict] = []
+        collections: List[Dict[str, Any]] = []
         for collection in user_collections:
             response = session.get(f"{API_URL}/collections/{collection.get("id")}")
             try:
@@ -209,11 +209,11 @@ class BitwardenPublicApi:
             return
 
         bw_user = self.get_user_by_email(email=str(user.email))
-        bw_user_collections = self.__get_user_collections(bw_user.get("collections"))
+        bw_user_collections = self.__get_user_collections(bw_user.get("collections", []))
         for bw_user_collection in bw_user_collections:
             if self.__collection_manually_created(bw_user_collection["id"]):
                 assign_collections.append(
-                    next(item for item in bw_user.get("collections") if item["id"] == bw_user_collection["id"])
+                    next(item for item in bw_user.get("collections", []) if item["id"] == bw_user_collection["id"])
                 )
 
         response = session.put(

--- a/bitwarden_manager/clients/bitwarden_public_api.py
+++ b/bitwarden_manager/clients/bitwarden_public_api.py
@@ -1,6 +1,6 @@
 import base64
 from logging import Logger
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 
 from requests import HTTPError, Session
 
@@ -16,6 +16,9 @@ session = Session()
 
 
 class BitwardenPublicApi:
+
+    bitwarden_access_token = None
+
     def __init__(self, logger: Logger, client_id: str, client_secret: str) -> None:
         self.__logger = logger
         self.__client_secret = client_secret
@@ -24,6 +27,21 @@ class BitwardenPublicApi:
     @staticmethod
     def external_id_base64_encoded(id: str) -> str:
         return base64.b64encode(id.encode()).decode("utf-8")
+
+    def __get_user_collections(self, user_collections: Optional[List[Dict]]) -> List[Dict]:
+        if user_collections is None:
+            return []
+
+        collections: List[Dict] = []
+        for collection in user_collections:
+            response = session.get(f"{API_URL}/collections/{collection.get("id")}")
+            try:
+                response.raise_for_status()
+            except HTTPError as error:
+                raise Exception("Failed to get collection", response.content, error) from error
+            collections.append(response.json())
+
+        return collections
 
     def __get_user_groups(self, user_id: str) -> List[str]:
         response = session.get(f"{API_URL}/members/{user_id}/group-ids")
@@ -62,6 +80,15 @@ class BitwardenPublicApi:
         else:
             raise Exception(f"No user with external_id {external_id} found")
 
+    def get_users(self) -> List[Dict[str, Any]]:
+        response = session.get(f"{API_URL}/members", timeout=REQUEST_TIMEOUT_SECONDS)
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise Exception("Failed to retrieve users", response.content, error) from error
+        response_json: Dict[str, Any] = response.json()
+        return list(response_json.get("data", []))
+
     def fetch_user_id_by_email(self, email: str) -> str:
         return str(self.get_user_by_email(email=email)["id"])
 
@@ -69,25 +96,26 @@ class BitwardenPublicApi:
         return str(self.get_user_by_external_id(external_id=external_id)["id"])
 
     def __fetch_token(self) -> str:
-        response = session.post(
-            LOGIN_URL,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data={
-                "grant_type": "client_credentials",
-                "scope": "api.organization",
-                "client_id": self.__client_id,
-                "client_secret": self.__client_secret,
-            },
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        try:
-            response.raise_for_status()
-        except HTTPError as error:
-            raise Exception(f"Failed to authenticate with {LOGIN_URL}, creds incorrect?", error) from error
-        response_json: Dict[str, str] = response.json()
-        access_token = response_json["access_token"]
-        session.headers.update({"Authorization": f"Bearer {access_token}"})
-        return access_token
+        if self.bitwarden_access_token is None:
+            response = session.post(
+                LOGIN_URL,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "client_credentials",
+                    "scope": "api.organization",
+                    "client_id": self.__client_id,
+                    "client_secret": self.__client_secret,
+                },
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            try:
+                response.raise_for_status()
+            except HTTPError as error:
+                raise Exception(f"Failed to authenticate with {LOGIN_URL}, creds incorrect?", error) from error
+            response_json: Dict[str, str] = response.json()
+            self.bitwarden_access_token = response_json["access_token"]
+        session.headers.update({"Authorization": f"Bearer {self.bitwarden_access_token}"})
+        return self.bitwarden_access_token
 
     def __get_collection(self, collection_id: str) -> Dict[str, Any]:
         response = session.get(f"{API_URL}/collections/{collection_id}")
@@ -113,15 +141,6 @@ class BitwardenPublicApi:
             return list(response_json.get("data", []))
         except HTTPError as error:
             raise Exception("Failed to list collections", response.content, error) from error
-
-    def get_users(self) -> List[Dict[str, Any]]:
-        response = session.get(f"{API_URL}/members", timeout=REQUEST_TIMEOUT_SECONDS)
-        try:
-            response.raise_for_status()
-        except HTTPError as error:
-            raise Exception("Failed to retrieve users", response.content, error) from error
-        response_json: Dict[str, Any] = response.json()
-        return list(response_json.get("data", []))
 
     def get_pending_users(self) -> List[Dict[str, Any]]:
         self.__fetch_token()
@@ -169,16 +188,14 @@ class BitwardenPublicApi:
             raise Exception(f"Failed to reinvite {username}", response.content, error) from error
 
     def grant_can_manage_permission_to_team_collections(self, user: UmpUser, teams: List[str]) -> None:
-
         collections = self.list_existing_collections(teams=teams)
-
-        permissions = []
+        assign_collections = []
         _can_manage_collections = []
         for key, value in collections.items():
             if value["id"] == "duplicate":
                 raise Exception(f"Duplicate collection found - {key}")
             if user.can_manage_team_collection(team=key):
-                permissions.append(
+                assign_collections.append(
                     {
                         "id": value["id"],
                         "readOnly": False,
@@ -188,10 +205,15 @@ class BitwardenPublicApi:
                 )
                 _can_manage_collections.append(key)
 
-        if len(permissions) == 0:
+        if len(assign_collections) == 0:
             return
 
         bw_user = self.get_user_by_email(email=str(user.email))
+        bw_user_collections = self.__get_user_collections(bw_user.get("collections"))
+        for bw_user_collection in bw_user_collections:
+            if self.__collection_manually_created(bw_user_collection["id"]):
+                assign_collections.append(next(item for item in bw_user.get("collections") if item["id"] == bw_user_collection["id"]))
+
         response = session.put(
             f"{API_URL}/members/{bw_user['id']}",
             json={
@@ -199,7 +221,7 @@ class BitwardenPublicApi:
                 "externalId": bw_user["externalId"],
                 "resetPasswordEnrolled": bw_user["resetPasswordEnrolled"],
                 "permissions": bw_user["permissions"],
-                "collections": permissions,
+                "collections": assign_collections,
             },
             timeout=REQUEST_TIMEOUT_SECONDS,
         )

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -48,7 +48,7 @@ def test_get_user_collections_returns_empty_list_when_collections_are_none() -> 
         client_secret="bar",
     )
 
-    result = client._BitwardenPublicApi__get_user_collections(None) # type: ignore
+    result = client._BitwardenPublicApi__get_user_collections(None)  # type: ignore
     assert result == []
 
 
@@ -76,7 +76,7 @@ def test_get_user_collections_returns_collections_where_collections_exist() -> N
                 json=collection,
             )
 
-        result = client._BitwardenPublicApi__get_user_collections(user_colletions) # type: ignore
+        result = client._BitwardenPublicApi__get_user_collections(user_colletions)  # type: ignore
         assert result == collections
 
 
@@ -96,9 +96,9 @@ def test_get_user_collections_throws_exception_when_collections_dont_exist() -> 
             status=404,
         )
 
-        client._BitwardenPublicApi__get_user_collections(None) # type: ignore
+        client._BitwardenPublicApi__get_user_collections(None)  # type: ignore
         with pytest.raises(Exception, match=r"Failed to get collection"):
-            client._BitwardenPublicApi__get_user_collections(user_collections) # type: ignore
+            client._BitwardenPublicApi__get_user_collections(user_collections)  # type: ignore
 
 
 def test_fetch_user_id_by_email() -> None:

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -48,7 +48,7 @@ def test_get_user_collections_returns_empty_list_when_collections_are_none() -> 
         client_secret="bar",
     )
 
-    result = client._BitwardenPublicApi__get_user_collections(None)
+    result = client._BitwardenPublicApi__get_user_collections(None) # type: ignore
     assert result == []
 
 
@@ -76,7 +76,7 @@ def test_get_user_collections_returns_collections_where_collections_exist() -> N
                 json=collection,
             )
 
-        result = client._BitwardenPublicApi__get_user_collections(user_colletions)
+        result = client._BitwardenPublicApi__get_user_collections(user_colletions) # type: ignore
         assert result == collections
 
 
@@ -96,9 +96,9 @@ def test_get_user_collections_throws_exception_when_collections_dont_exist() -> 
             status=404,
         )
 
-        client._BitwardenPublicApi__get_user_collections(None)
+        client._BitwardenPublicApi__get_user_collections(None) # type: ignore
         with pytest.raises(Exception, match=r"Failed to get collection"):
-            client._BitwardenPublicApi__get_user_collections(user_collections)
+            client._BitwardenPublicApi__get_user_collections(user_collections) # type: ignore
 
 
 def test_fetch_user_id_by_email() -> None:

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -58,8 +58,8 @@ def test_get_user_collections_returns_collections_where_collections_exist() -> N
     )
 
     user_colletions = [
-        _user_collection_object_with_empty_external_id("manually-created"),
-        _user_collection_object_with_base64_encoded_external_id("manager-created")
+        _user_collection("manually-created"),
+        _user_collection("manager-created")
     ]
 
     collections = [
@@ -88,7 +88,7 @@ def test_get_user_collections_throws_exception_when_collections_dont_exist() -> 
     )
 
     user_collections = [
-        _user_collection_object_with_empty_external_id("non-existent")
+        _user_collection("non-existent")
     ]
 
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
@@ -147,8 +147,8 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
         roles_by_team={"team-one": "team_admin", "team-two": "all_team_admin"},
     )
     user_collections = [
-        _collection_object_with_empty_external_id("manually-created"),
-        _collection_object_with_base64_encoded_external_id("manager-created"),
+        _collection_object_with_empty_external_id("manually-created", groups=[]),
+        _collection_object_with_base64_encoded_external_id("manager-created", groups=[]),
     ]
 
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
@@ -164,7 +164,8 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                 "data": [
                     _collection_object_with_base64_encoded_external_id("team-one", groups=[]),
                     _collection_object_with_base64_encoded_external_id("team-two", groups=[]),
-                    _collection_object_with_empty_external_id("manually-created"),
+                    _collection_object_with_base64_encoded_external_id("manager-created", groups=[]),
+                    _collection_object_with_empty_external_id("manually-created", groups=[]),
                 ]
             },
         )
@@ -191,9 +192,9 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                         "resetPasswordEnrolled": False,
                         "permissions": None,
                         "collections": [
-                            {"id": "id-team-one", "readOnly": False, "hidePasswords": False, "manage": True},
-                            {"id": "id-team-two", "readOnly": False, "hidePasswords": False, "manage": True},
-                            {"id": "id-manually-created", "readOnly": False, "hidePasswords": False, "manage": True},
+                            _user_collection(name="team-one",  readOnly=False, manage=True),
+                            _user_collection(name="team-two", readOnly=False, manage=True),
+                            _user_collection(name="manually-created", readOnly=False, manage=True)
                         ],
                         # "groups": [],
                     }
@@ -212,9 +213,9 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                 "twoFactorEnabled": True,
                 "status": 0,
                 "collections": [
-                    {"id": "id-team-one", "readOnly": False, "hidePasswords": False, "manage": True},
-                    {"id": "id-team-two", "readOnly": False, "hidePasswords": False, "manage": True},
-                    {"id": "id-manually-created", "readOnly": False, "hidePasswords": False, "manage": True},
+                    _user_collection(name="team-one", readOnly=False, manage=True),
+                    _user_collection(name="team-two", readOnly=False, manage=True),
+                    _user_collection(name="manually-created", readOnly=False, manage=True)
                 ],
             },
         )
@@ -235,7 +236,7 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
         rsps.add(
             status=400,
             content_type="application/json",
-            method=responses.PUT,
+            method=rsps.PUT,
             url=f"https://api.bitwarden.eu/public/members/{member_id}",
             json={"error": "error"},
         )
@@ -249,7 +250,7 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
         rsps.add(
             status=200,
             content_type="application/json",
-            method="GET",
+            method=rsps.GET,
             url="https://api.bitwarden.eu/public/collections",
             json={
                 "data": [
@@ -1569,15 +1570,7 @@ def _collection_object_with_empty_external_id(name: str, groups: List[Dict[str, 
         "groups": groups,
     }
 
-def _user_collection_object_with_base64_encoded_external_id(name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False) -> Dict[str, Any]:
-    return {
-        "id": _collection_id(name),
-        "readOnly": readOnly,
-        "hidePasswords": hidePasswords,
-        "manage": manage
-    }
-
-def _user_collection_object_with_empty_external_id(name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False) -> Dict[str, Any]:
+def _user_collection(name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False) -> Dict[str, Any]:
     return {
         "id": _collection_id(name),
         "readOnly": readOnly,

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -17,7 +17,7 @@ MOCKED_GET_MEMBERS = responses.Response(
     method=responses.GET,
     url="https://api.bitwarden.eu/public/members",
     body=open("tests/bitwarden_manager/resources/get_members.json").read(),
-    #body=open("../resources/get_members.json").read(),
+    # body=open("../resources/get_members.json").read(),
 )
 
 
@@ -40,6 +40,7 @@ def test_get_user_by_email() -> None:
         with pytest.raises(Exception, match=r"No user with email .* found"):
             client.get_user_by_email(email="does.not.exist@example.com")
 
+
 def test_get_user_collections_returns_empty_list_when_collections_are_none() -> None:
     client = BitwardenPublicApi(
         logger=logging.getLogger(),
@@ -50,6 +51,7 @@ def test_get_user_collections_returns_empty_list_when_collections_are_none() -> 
     result = client._BitwardenPublicApi__get_user_collections(None)
     assert result == []
 
+
 def test_get_user_collections_returns_collections_where_collections_exist() -> None:
     client = BitwardenPublicApi(
         logger=logging.getLogger(),
@@ -57,14 +59,11 @@ def test_get_user_collections_returns_collections_where_collections_exist() -> N
         client_secret="bar",
     )
 
-    user_colletions = [
-        _user_collection("manually-created"),
-        _user_collection("manager-created")
-    ]
+    user_colletions = [_user_collection("manually-created"), _user_collection("manager-created")]
 
     collections = [
         _collection_object_with_empty_external_id("manually-created"),
-        _collection_object_with_base64_encoded_external_id("manager-created")
+        _collection_object_with_base64_encoded_external_id("manager-created"),
     ]
 
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
@@ -80,6 +79,7 @@ def test_get_user_collections_returns_collections_where_collections_exist() -> N
         result = client._BitwardenPublicApi__get_user_collections(user_colletions)
         assert result == collections
 
+
 def test_get_user_collections_throws_exception_when_collections_dont_exist() -> None:
     client = BitwardenPublicApi(
         logger=logging.getLogger(),
@@ -87,9 +87,7 @@ def test_get_user_collections_throws_exception_when_collections_dont_exist() -> 
         client_secret="bar",
     )
 
-    user_collections = [
-        _user_collection("non-existent")
-    ]
+    user_collections = [_user_collection("non-existent")]
 
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         rsps.add(
@@ -101,6 +99,7 @@ def test_get_user_collections_throws_exception_when_collections_dont_exist() -> 
         client._BitwardenPublicApi__get_user_collections(None)
         with pytest.raises(Exception, match=r"Failed to get collection"):
             client._BitwardenPublicApi__get_user_collections(user_collections)
+
 
 def test_fetch_user_id_by_email() -> None:
     email = "test.user01@example.com"
@@ -192,9 +191,9 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                         "resetPasswordEnrolled": False,
                         "permissions": None,
                         "collections": [
-                            _user_collection(name="team-one",  readOnly=False, manage=True),
+                            _user_collection(name="team-one", readOnly=False, manage=True),
                             _user_collection(name="team-two", readOnly=False, manage=True),
-                            _user_collection(name="manually-created", readOnly=False, manage=True)
+                            _user_collection(name="manually-created", readOnly=False, manage=True),
                         ],
                         # "groups": [],
                     }
@@ -215,7 +214,7 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                 "collections": [
                     _user_collection(name="team-one", readOnly=False, manage=True),
                     _user_collection(name="team-two", readOnly=False, manage=True),
-                    _user_collection(name="manually-created", readOnly=False, manage=True)
+                    _user_collection(name="manually-created", readOnly=False, manage=True),
                 ],
             },
         )
@@ -1562,6 +1561,7 @@ def _collection_object_with_unencoded_external_id(name: str, groups: List[Dict[s
         "groups": groups,
     }
 
+
 def _collection_object_with_empty_external_id(name: str, groups: List[Dict[str, Any]] = []) -> Dict[str, Any]:
     return {
         "externalId": "",
@@ -1570,10 +1570,8 @@ def _collection_object_with_empty_external_id(name: str, groups: List[Dict[str, 
         "groups": groups,
     }
 
-def _user_collection(name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False) -> Dict[str, Any]:
-    return {
-        "id": _collection_id(name),
-        "readOnly": readOnly,
-        "hidePasswords": hidePasswords,
-        "manage": manage
-    }
+
+def _user_collection(
+    name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False
+) -> Dict[str, Any]:
+    return {"id": _collection_id(name), "readOnly": readOnly, "hidePasswords": hidePasswords, "manage": manage}

--- a/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
+++ b/tests/bitwarden_manager/clients/test_bitwarden_public_api.py
@@ -17,6 +17,7 @@ MOCKED_GET_MEMBERS = responses.Response(
     method=responses.GET,
     url="https://api.bitwarden.eu/public/members",
     body=open("tests/bitwarden_manager/resources/get_members.json").read(),
+    #body=open("../resources/get_members.json").read(),
 )
 
 
@@ -39,6 +40,67 @@ def test_get_user_by_email() -> None:
         with pytest.raises(Exception, match=r"No user with email .* found"):
             client.get_user_by_email(email="does.not.exist@example.com")
 
+def test_get_user_collections_returns_empty_list_when_collections_are_none() -> None:
+    client = BitwardenPublicApi(
+        logger=logging.getLogger(),
+        client_id="foo",
+        client_secret="bar",
+    )
+
+    result = client._BitwardenPublicApi__get_user_collections(None)
+    assert result == []
+
+def test_get_user_collections_returns_collections_where_collections_exist() -> None:
+    client = BitwardenPublicApi(
+        logger=logging.getLogger(),
+        client_id="foo",
+        client_secret="bar",
+    )
+
+    user_colletions = [
+        _user_collection_object_with_empty_external_id("manually-created"),
+        _user_collection_object_with_base64_encoded_external_id("manager-created")
+    ]
+
+    collections = [
+        _collection_object_with_empty_external_id("manually-created"),
+        _collection_object_with_base64_encoded_external_id("manager-created")
+    ]
+
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        for collection in collections:
+            rsps.add(
+                status=200,
+                content_type="application/json",
+                method=rsps.GET,
+                url=f"https://api.bitwarden.eu/public/collections/{collection["id"]}",
+                json=collection,
+            )
+
+        result = client._BitwardenPublicApi__get_user_collections(user_colletions)
+        assert result == collections
+
+def test_get_user_collections_throws_exception_when_collections_dont_exist() -> None:
+    client = BitwardenPublicApi(
+        logger=logging.getLogger(),
+        client_id="foo",
+        client_secret="bar",
+    )
+
+    user_collections = [
+        _user_collection_object_with_empty_external_id("non-existent")
+    ]
+
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(
+            rsps.GET,
+            f"https://api.bitwarden.eu/public/collections/{user_collections[0]["id"]}",
+            status=404,
+        )
+
+        client._BitwardenPublicApi__get_user_collections(None)
+        with pytest.raises(Exception, match=r"Failed to get collection"):
+            client._BitwardenPublicApi__get_user_collections(user_collections)
 
 def test_fetch_user_id_by_email() -> None:
     email = "test.user01@example.com"
@@ -84,25 +146,42 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
         email="test.user02@example.com",
         roles_by_team={"team-one": "team_admin", "team-two": "all_team_admin"},
     )
+    user_collections = [
+        _collection_object_with_empty_external_id("manually-created"),
+        _collection_object_with_base64_encoded_external_id("manager-created"),
+    ]
+
     with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
         rsps.add(MOCKED_LOGIN)
         rsps.add(MOCKED_GET_MEMBERS)
+
         rsps.add(
             status=200,
             content_type="application/json",
-            method="GET",
+            method=rsps.GET,
             url="https://api.bitwarden.eu/public/collections",
             json={
                 "data": [
                     _collection_object_with_base64_encoded_external_id("team-one", groups=[]),
                     _collection_object_with_base64_encoded_external_id("team-two", groups=[]),
+                    _collection_object_with_empty_external_id("manually-created"),
                 ]
             },
         )
+
+        for collection in user_collections:
+            rsps.add(
+                status=200,
+                content_type="application/json",
+                method=rsps.GET,
+                url=f"https://api.bitwarden.eu/public/collections/{collection["id"]}",
+                json=collection,
+            )
+
         rsps.add(
             status=200,
             content_type="application/json",
-            method=responses.PUT,
+            method=rsps.PUT,
             url=f"https://api.bitwarden.eu/public/members/{member_id}",
             match=[
                 matchers.json_params_matcher(
@@ -114,6 +193,7 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                         "collections": [
                             {"id": "id-team-one", "readOnly": False, "hidePasswords": False, "manage": True},
                             {"id": "id-team-two", "readOnly": False, "hidePasswords": False, "manage": True},
+                            {"id": "id-manually-created", "readOnly": False, "hidePasswords": False, "manage": True},
                         ],
                         # "groups": [],
                     }
@@ -131,7 +211,11 @@ def test_grant_can_manage_permission_to_team_collections_to_team_admin() -> None
                 "email": user.email,
                 "twoFactorEnabled": True,
                 "status": 0,
-                "collections": [],
+                "collections": [
+                    {"id": "id-team-one", "readOnly": False, "hidePasswords": False, "manage": True},
+                    {"id": "id-team-two", "readOnly": False, "hidePasswords": False, "manage": True},
+                    {"id": "id-manually-created", "readOnly": False, "hidePasswords": False, "manage": True},
+                ],
             },
         )
 
@@ -1475,4 +1559,28 @@ def _collection_object_with_unencoded_external_id(name: str, groups: List[Dict[s
         "object": "collection",
         "id": _collection_id(name),
         "groups": groups,
+    }
+
+def _collection_object_with_empty_external_id(name: str, groups: List[Dict[str, Any]] = []) -> Dict[str, Any]:
+    return {
+        "externalId": "",
+        "object": "collection",
+        "id": _collection_id(name),
+        "groups": groups,
+    }
+
+def _user_collection_object_with_base64_encoded_external_id(name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False) -> Dict[str, Any]:
+    return {
+        "id": _collection_id(name),
+        "readOnly": readOnly,
+        "hidePasswords": hidePasswords,
+        "manage": manage
+    }
+
+def _user_collection_object_with_empty_external_id(name: str, readOnly: bool = True, hidePasswords: bool = False, manage: bool = False) -> Dict[str, Any]:
+    return {
+        "id": _collection_id(name),
+        "readOnly": readOnly,
+        "hidePasswords": hidePasswords,
+        "manage": manage
     }

--- a/tests/bitwarden_manager/resources/get_members.json
+++ b/tests/bitwarden_manager/resources/get_members.json
@@ -24,7 +24,18 @@
         "email": "test.user02@example.com",
         "twoFactorEnabled": true,
         "status": 2,
-        "collections": null,
+        "collections": [{
+            "id": "id-manager-created",
+            "readOnly": true,
+            "hidePasswords": false,
+            "manage": false
+          },
+        {
+          "id": "id-manually-created",
+          "readOnly": false,
+          "hidePasswords": false,
+          "manage": true
+        }],
         "type": 2,
         "accessAll": false,
         "externalId": "test.user02",


### PR DESCRIPTION
Fix for the clobber behavior when users are granted permissions to manage a collection by team

Added https://github.com/hmrc/bitwarden-manager/compare/PSEC-2225/fix-collection-clobber?expand=1#diff-5de742da245f6dd3de2b119f1cd459f3db383e02e790290f204ffba66e0e8317R98 in theory, this should stop multiple logins for multiple calls to the api