### PR TITLE
DOD-3427: Update UMP event schema

### DIFF
--- a/bitwarden_manager/offboard_user.py
+++ b/bitwarden_manager/offboard_user.py
@@ -15,6 +15,11 @@ offboard_user_event_schema = {
             "pattern": "remove_user",
         },
         "username": {"type": "string", "description": "the users ldap username"},
+        "service_name": {
+            "type": "string",
+            "description": "name of the service which invoked the event",
+            "enum": ["all", "bitwarden"]
+        },
     },
     "required": ["event_name", "username"],
 }

--- a/bitwarden_manager/offboard_user.py
+++ b/bitwarden_manager/offboard_user.py
@@ -12,13 +12,13 @@ offboard_user_event_schema = {
         "event_name": {
             "type": "string",
             "description": "name of the current event",
-            "pattern": "remove_user",
+            "const": "remove_user",
         },
         "username": {"type": "string", "description": "the users ldap username"},
         "service_name": {
             "type": "string",
             "description": "name of the service which invoked the event",
-            "enum": ["all", "bitwarden"]
+            "enum": ["all", "bitwarden"],
         },
     },
     "required": ["event_name", "username"],

--- a/bitwarden_manager/onboard_user.py
+++ b/bitwarden_manager/onboard_user.py
@@ -16,7 +16,7 @@ onboard_user_event_schema = {
         "event_name": {
             "type": "string",
             "description": "name of the current event",
-            "pattern": "new_user",
+            "const": "new_user",
         },
         "username": {"type": "string", "description": "the users ldap username"},
         "email": {
@@ -27,8 +27,8 @@ onboard_user_event_schema = {
         "service_name": {
             "type": "string",
             "description": "name of the service which invoked the event",
-            "enum": ["all", "bitwarden"]
-        }
+            "enum": ["all", "bitwarden"],
+        },
     },
     "required": ["event_name", "username", "email"],
 }

--- a/bitwarden_manager/onboard_user.py
+++ b/bitwarden_manager/onboard_user.py
@@ -24,6 +24,11 @@ onboard_user_event_schema = {
             "pattern": "^(.+)@(.+)$",
             "description": "The users full work email address",
         },
+        "service_name": {
+            "type": "string",
+            "description": "name of the service which invoked the event",
+            "enum": ["all", "bitwarden"]
+        }
     },
     "required": ["event_name", "username", "email"],
 }


### PR DESCRIPTION
UMP is moving towards a generic SNS topic that services can subscribe to
for notifications of all user events. To make this possible, a new
message property "service_name" has been added to allow for services to
filter only relevant messages.

Add service_name property to onboard_user and offboard_user event
schemas.

----------

During testing we found that "event_name"s specified by pattern could
match substrings of the event's property. Using const only allows exact
values.

Only allow exact event_name for onboard_user and offboard_user event
schemas.